### PR TITLE
Charm resource injection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "2.1.2.3"
+version = "2.1.2.4"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -127,11 +127,16 @@ class _MockModelBackend(_ModelBackend):
 
     def config_get(self):
         state_config = self._state.config
-        if not state_config:
-            state_config = {
-                key: value.get("default")
-                for key, value in self._charm_spec.config.items()
-            }
+
+        # add defaults
+        charm_config = self._charm_spec.config
+        if not charm_config:
+            return state_config
+
+        for key, value in charm_config["options"].items():
+            # if it has a default, and it's not overwritten from State, use it:
+            if key not in state_config and (default_value := value.get("default")):
+                state_config[key] = default_value
 
         return state_config  # full config
 

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -350,6 +350,29 @@ def trigger(
     config: Optional[Dict[str, Any]] = None,
     copy_to_charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
 ) -> "State":
+    """Trigger a charm execution with an Event and a State.
+
+    Calling this function will call ops' main() and set up the context according to the specified
+    State, then emit the event on the charm.
+
+    :arg event: the Event that the charm will respond to. Can be a string or an Event instance.
+    :arg state: the State instance to use as data source for the hook tool calls that the charm will
+        invoke when handling the Event.
+    :arg charm_type: the CharmBase subclass to call ``ops.main()`` on.
+    :arg pre_event: callback to be invoked right before emitting the event on the newly
+        instantiated charm. Will receive the charm instance as only positional argument.
+    :arg post_event: callback to be invoked right after emitting the event on the charm instance.
+        Will receive the charm instance as only positional argument.
+    :arg meta: charm metadata to use. Needs to be a valid metadata.yaml format (as a python dict).
+        If none is provided, we will search for a ``metadata.yaml`` file in the charm root.
+    :arg actions: charm actions to use. Needs to be a valid actions.yaml format (as a python dict).
+        If none is provided, we will search for a ``actions.yaml`` file in the charm root.
+    :arg config: charm config to use. Needs to be a valid config.yaml format (as a python dict).
+        If none is provided, we will search for a ``config.yaml`` file in the charm root.
+    :arg copy_to_charm_root: files to copy to the virtual charm root that we create when executing
+        the charm. If the charm, say, expects a `./src/foo/bar.yaml` file present relative to the
+        execution cwd, you need to specify that here.
+    """
     from scenario.state import Event, _CharmSpec
 
     if isinstance(event, str):

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -372,6 +372,12 @@ def trigger(
     :arg copy_to_charm_root: files to copy to the virtual charm root that we create when executing
         the charm. If the charm, say, expects a `./src/foo/bar.yaml` file present relative to the
         execution cwd, you need to specify that here.
+        The format is {destination_path: source_path}; so for the aforementioned scenario you
+        would:
+        >>> local_file = tempfile.NamedTemporaryFile(suffix='yaml')
+        >>> local_path = Path(local_path.name)
+        >>> local_path.write_text('foo: bar')
+        >>> scenario.State().trigger(..., copy_to_charm_root = {'./src/foo/bar.yaml': local_path})
     """
     from scenario.state import Event, _CharmSpec
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -493,7 +493,9 @@ class State(_DCBase):
             status=dataclasses.replace(self.status, unit=(status, message))
         )
 
-    def get_container(self, name) -> Container:
+    def get_container(self, container: Union[str, Container]) -> Container:
+        """Get container from this State, based on an input container or its name."""
+        name = container.name if isinstance(container, Container) else container
         try:
             return next(filter(lambda c: c.name == name, self.containers))
         except StopIteration as e:

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -25,6 +25,8 @@ if typing.TYPE_CHECKING:
         from typing_extensions import Self
     from ops.testing import CharmType
 
+    PathLike = Union[str, Path]
+
 logger = scenario_logger.getChild("structs")
 
 ATTACH_ALL_STORAGES = "ATTACH_ALL_STORAGES"
@@ -318,13 +320,13 @@ class Container(_DCBase):
                 # but it ignores services it doesn't recognize
                 continue
             status = self.service_status.get(name, pebble.ServiceStatus.INACTIVE)
-            if service.startup == '':
+            if service.startup == "":
                 startup = pebble.ServiceStartup.DISABLED
             else:
                 startup = pebble.ServiceStartup(service.startup)
-            info = pebble.ServiceInfo(name,
-                                      startup=startup,
-                                      current=pebble.ServiceStatus(status))
+            info = pebble.ServiceInfo(
+                name, startup=startup, current=pebble.ServiceStatus(status)
+            )
             infos[name] = info
         return infos
 
@@ -413,7 +415,6 @@ class Network(_DCBase):
                     ],
                 )
             ],
-            bind_address=private_address,
             egress_subnets=list(egress_subnets),
             ingress_addresses=list(ingress_addresses),
         )
@@ -444,7 +445,9 @@ class StoredState(_DCBase):
 
 @dataclasses.dataclass
 class State(_DCBase):
-    config: Dict[str, Union[str, int, float, bool]] = dataclasses.field(default_factory=dict)
+    config: Dict[str, Union[str, int, float, bool]] = dataclasses.field(
+        default_factory=dict
+    )
     relations: List[Relation] = dataclasses.field(default_factory=list)
     networks: List[Network] = dataclasses.field(default_factory=list)
     containers: List[Container] = dataclasses.field(default_factory=list)
@@ -523,7 +526,7 @@ class State(_DCBase):
         meta: Optional[Dict[str, Any]] = None,
         actions: Optional[Dict[str, Any]] = None,
         config: Optional[Dict[str, Any]] = None,
-        resources: Optional[Dict[Path, Path]] = None,
+        copy_to_charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
     ):
         """Fluent API for trigger."""
         return trigger(
@@ -535,7 +538,7 @@ class State(_DCBase):
             meta=meta,
             actions=actions,
             config=config,
-            resources=resources,
+            copy_to_charm_root=copy_to_charm_root,
         )
 
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -528,7 +528,7 @@ class State(_DCBase):
         meta: Optional[Dict[str, Any]] = None,
         actions: Optional[Dict[str, Any]] = None,
         config: Optional[Dict[str, Any]] = None,
-        copy_to_charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
+        charm_root: Optional["PathLike"] = None,
     ):
         """Fluent API for trigger. See runtime.trigger's docstring."""
         return _runtime_trigger(
@@ -540,7 +540,7 @@ class State(_DCBase):
             meta=meta,
             actions=actions,
             config=config,
-            copy_to_charm_root=copy_to_charm_root,
+            charm_root=charm_root,
         )
 
     trigger.__doc__ = _runtime_trigger.__doc__

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -16,7 +16,7 @@ from ops.model import SecretRotate
 
 from scenario.logger import logger as scenario_logger
 from scenario.mocking import _MockFileSystem, _MockStorageMount
-from scenario.runtime import trigger
+from scenario.runtime import trigger as _runtime_trigger
 
 if typing.TYPE_CHECKING:
     try:
@@ -530,8 +530,8 @@ class State(_DCBase):
         config: Optional[Dict[str, Any]] = None,
         copy_to_charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
     ):
-        """Fluent API for trigger."""
-        return trigger(
+        """Fluent API for trigger. See runtime.trigger's docstring."""
+        return _runtime_trigger(
             state=self,
             event=event,
             charm_type=charm_type,
@@ -542,6 +542,8 @@ class State(_DCBase):
             config=config,
             copy_to_charm_root=copy_to_charm_root,
         )
+
+    trigger.__doc__ = _runtime_trigger.__doc__
 
 
 @dataclasses.dataclass

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -523,6 +523,7 @@ class State(_DCBase):
         meta: Optional[Dict[str, Any]] = None,
         actions: Optional[Dict[str, Any]] = None,
         config: Optional[Dict[str, Any]] = None,
+        resources: Optional[Dict[Path, Path]] = None,
     ):
         """Fluent API for trigger."""
         return trigger(
@@ -534,6 +535,7 @@ class State(_DCBase):
             meta=meta,
             actions=actions,
             config=config,
+            resources=resources,
         )
 
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -555,6 +555,10 @@ class _CharmSpec(_DCBase):
     actions: Optional[Dict[str, Any]] = None
     config: Optional[Dict[str, Any]] = None
 
+    # autoloaded means: trigger() is being invoked on a 'real' charm class, living in some /src/charm.py,
+    # and the metadata files are 'real' metadata files.
+    is_autoloaded: bool = False
+
     @staticmethod
     def autoload(charm_type: Type["CharmType"]):
         charm_source_path = Path(inspect.getfile(charm_type))
@@ -574,7 +578,11 @@ class _CharmSpec(_DCBase):
             actions = yaml.safe_load(actions_path.open())
 
         return _CharmSpec(
-            charm_type=charm_type, meta=meta, actions=actions, config=config
+            charm_type=charm_type,
+            meta=meta,
+            actions=actions,
+            config=config,
+            is_autoloaded=True,
         )
 
 

--- a/tests/test_e2e/test_config.py
+++ b/tests/test_e2e/test_config.py
@@ -1,0 +1,55 @@
+import pytest
+from ops.charm import CharmBase
+from ops.framework import Framework
+
+from scenario import trigger
+from scenario.state import Event, Network, Relation, State, _CharmSpec
+
+
+@pytest.fixture(scope="function")
+def mycharm():
+    class MyCharm(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            for evt in self.on.events().values():
+                self.framework.observe(evt, self._on_event)
+
+        def _on_event(self, event):
+            pass
+
+    return MyCharm
+
+
+def test_config_get(mycharm):
+    def check_cfg(charm: CharmBase):
+        assert charm.config["foo"] == "bar"
+        assert charm.config["baz"] == 1
+
+    trigger(
+        State(
+            config={"foo": "bar", "baz": 1},
+        ),
+        "update-status",
+        mycharm,
+        meta={"name": "foo"},
+        post_event=check_cfg,
+    )
+
+
+def test_config_get_default_from_meta(mycharm):
+    def check_cfg(charm: CharmBase):
+        assert charm.config["foo"] == "bar"
+        assert charm.config["baz"] == 2
+
+    trigger(
+        State(
+            config={"foo": "bar"},
+        ),
+        "update-status",
+        mycharm,
+        meta={"name": "foo"},
+        config={
+            "options": {"baz": {"type": "integer", "default": 2}},
+        },
+        post_event=check_cfg,
+    )

--- a/tests/test_e2e/test_pebble.py
+++ b/tests/test_e2e/test_pebble.py
@@ -157,8 +157,8 @@ PS = """
 @pytest.mark.parametrize(
     "cmd, out",
     (
-            ("ls", LS),
-            ("ps", PS),
+        ("ls", LS),
+        ("ps", PS),
     ),
 )
 def test_exec(charm_cls, cmd, out):
@@ -249,7 +249,7 @@ def test_pebble_plan(charm_cls, starting_service_status):
             "fooserv": pebble.ServiceStatus.ACTIVE,
             # todo: should we disallow setting status for services that aren't known YET?
             "barserv": starting_service_status,
-        }
+        },
     )
 
     out = State(containers=[container]).trigger(
@@ -262,10 +262,11 @@ def test_pebble_plan(charm_cls, starting_service_status):
     serv = lambda name, obj: pebble.Service(name, raw=obj)
     container = out.containers[0]
     assert container.plan.services == {
-        'barserv': serv('barserv', {'startup': 'disabled'}),
-        'fooserv': serv('fooserv', {'startup': 'enabled'})}
-    assert container.services['fooserv'].current == pebble.ServiceStatus.ACTIVE
-    assert container.services['fooserv'].startup == pebble.ServiceStartup.ENABLED
+        "barserv": serv("barserv", {"startup": "disabled"}),
+        "fooserv": serv("fooserv", {"startup": "enabled"}),
+    }
+    assert container.services["fooserv"].current == pebble.ServiceStatus.ACTIVE
+    assert container.services["fooserv"].startup == pebble.ServiceStartup.ENABLED
 
-    assert container.services['barserv'].current == pebble.ServiceStatus.ACTIVE
-    assert container.services['barserv'].startup == pebble.ServiceStartup.DISABLED
+    assert container.services["barserv"].current == pebble.ServiceStatus.ACTIVE
+    assert container.services["barserv"].startup == pebble.ServiceStartup.DISABLED

--- a/tests/test_e2e/test_vroot.py
+++ b/tests/test_e2e/test_vroot.py
@@ -19,25 +19,24 @@ class MyCharm(CharmBase):
         self.unit.status = ActiveStatus(f"{foo.read_text()} {baz.read_text()}")
 
 
-def test_resources():
-    with tempfile.TemporaryDirectory() as td:
-        t = Path(td)
-        foobar = t / "foo.bar"
+def test_vroot():
+    with tempfile.TemporaryDirectory() as myvroot:
+        t = Path(myvroot)
+        src = t / "src"
+        src.mkdir()
+        foobar = src / "foo.bar"
         foobar.write_text("hello")
 
-        baz = t / "baz"
+        baz = src / "baz"
         baz.mkdir(parents=True)
-        quxcos = baz / "qux.cos"
+        quxcos = baz / "qux.kaboodle"
         quxcos.write_text("world")
 
         out = State().trigger(
             "start",
             charm_type=MyCharm,
             meta=MyCharm.META,
-            copy_to_charm_root={
-                "/src/foo.bar": foobar,
-                "/src/baz/qux.kaboodle": quxcos,
-            },
+            charm_root=t,
         )
 
     assert out.status.unit == ("active", "hello world")

--- a/tests/test_e2e/test_vroot_resources.py
+++ b/tests/test_e2e/test_vroot_resources.py
@@ -1,0 +1,39 @@
+import tempfile
+from pathlib import Path
+
+from ops.charm import CharmBase
+from ops.framework import Framework
+from ops.model import ActiveStatus
+
+from scenario import State
+
+
+class MyCharm(CharmBase):
+    META = {'name': 'my-charm'}
+
+    def __init__(self, framework: Framework):
+        super().__init__(framework)
+        foo = self.framework.charm_dir / 'src' / 'foo.bar'
+        baz = self.framework.charm_dir / 'src' / 'baz' / 'qux.kaboodle'
+
+        self.unit.status = ActiveStatus(f"{foo.read_text()} {baz.read_text()}")
+
+
+def test_resources():
+    with tempfile.TemporaryDirectory() as td:
+        t = Path(td)
+        foobar = t / 'foo.bar'
+        foobar.write_text('hello')
+
+        baz = t / 'baz'
+        baz.mkdir(parents=True)
+        quxcos = (baz / 'qux.cos')
+        quxcos.write_text('world')
+
+        out = State().trigger(
+            'start',
+            charm_type=MyCharm, meta=MyCharm.META,
+            resources={foobar: Path('/src/foo.bar'), quxcos: Path('/src/baz/qux.kaboodle')}
+        )
+
+    assert out.status.unit == ('active', 'hello world')

--- a/tests/test_e2e/test_vroot_resources.py
+++ b/tests/test_e2e/test_vroot_resources.py
@@ -9,12 +9,12 @@ from scenario import State
 
 
 class MyCharm(CharmBase):
-    META = {'name': 'my-charm'}
+    META = {"name": "my-charm"}
 
     def __init__(self, framework: Framework):
         super().__init__(framework)
-        foo = self.framework.charm_dir / 'src' / 'foo.bar'
-        baz = self.framework.charm_dir / 'src' / 'baz' / 'qux.kaboodle'
+        foo = self.framework.charm_dir / "src" / "foo.bar"
+        baz = self.framework.charm_dir / "src" / "baz" / "qux.kaboodle"
 
         self.unit.status = ActiveStatus(f"{foo.read_text()} {baz.read_text()}")
 
@@ -22,18 +22,22 @@ class MyCharm(CharmBase):
 def test_resources():
     with tempfile.TemporaryDirectory() as td:
         t = Path(td)
-        foobar = t / 'foo.bar'
-        foobar.write_text('hello')
+        foobar = t / "foo.bar"
+        foobar.write_text("hello")
 
-        baz = t / 'baz'
+        baz = t / "baz"
         baz.mkdir(parents=True)
-        quxcos = (baz / 'qux.cos')
-        quxcos.write_text('world')
+        quxcos = baz / "qux.cos"
+        quxcos.write_text("world")
 
         out = State().trigger(
-            'start',
-            charm_type=MyCharm, meta=MyCharm.META,
-            resources={foobar: Path('/src/foo.bar'), quxcos: Path('/src/baz/qux.kaboodle')}
+            "start",
+            charm_type=MyCharm,
+            meta=MyCharm.META,
+            copy_to_charm_root={
+                "/src/foo.bar": foobar,
+                "/src/baz/qux.kaboodle": quxcos,
+            },
         )
 
-    assert out.status.unit == ('active', 'hello world')
+    assert out.status.unit == ("active", "hello world")


### PR DESCRIPTION
Fixes #4 

Adds API to control the virtual charm execution root.

For example:

```
my_temp_dir = TemporaryDirectory()
State().trigger(MyCharm, charm_root=my_temp_dir)
```

this will make it so that the charm's `framework.charm_dir` points to that temporary directory. So if the charm were to try and read files from that directory, the test can ensure that they are available, and if the charm were to write files to it, the test can ensure that they are there.