### PR TITLE
Native StatusBase comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ With that, we can write the simplest possible scenario test:
 ```python
 from scenario.state import State
 from ops.charm import CharmBase
-
+from ops.model import UnknownStatus
 
 class MyCharm(CharmBase):
     pass
@@ -74,7 +74,7 @@ def test_scenario_base():
     out = State().trigger(
         'start', 
         MyCharm, meta={"name": "foo"})
-    assert out.status.unit == ('unknown', '')
+    assert out.status.unit == UnknownStatus()
 ```
 
 Now let's start making it more complicated.
@@ -104,7 +104,7 @@ def test_status_leader(leader):
         'start', 
         MyCharm,
         meta={"name": "foo"})
-    assert out.status.unit == ('active', 'I rule' if leader else 'I am ruled')
+    assert out.status.unit == ActiveStatus('I rule' if leader else 'I am ruled')
 ```
 
 By defining the right state we can programmatically define what answers will the charm get to all the questions it can ask the juju model: am I leader? What are my relations? What is the remote unit I'm talking to? etc...

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -444,6 +444,9 @@ class _EntityStatus(_DCBase):
     def __iter__(self):
         return iter([self.name, self.message])
 
+    def __repr__(self):
+        return f"<EntityStatus name={self.name}, message={self.message}>"
+
 
 @dataclasses.dataclass
 class Status(_DCBase):
@@ -464,7 +467,7 @@ class Status(_DCBase):
                                f'Please pass a StatusBase instance: `StatusBase(*{val})`')
                 setattr(self, name, _EntityStatus(*val))
             else:
-                raise TypeError(f"Invalid {self}.{name}: {val!r}")
+                raise TypeError(f"Invalid status.{name}: {val!r}")
 
 
 @dataclasses.dataclass

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -413,7 +413,6 @@ class Network(_DCBase):
                     ],
                 )
             ],
-            bind_address=private_address,
             egress_subnets=list(egress_subnets),
             ingress_addresses=list(ingress_addresses),
         )

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -318,13 +318,13 @@ class Container(_DCBase):
                 # but it ignores services it doesn't recognize
                 continue
             status = self.service_status.get(name, pebble.ServiceStatus.INACTIVE)
-            if service.startup == '':
+            if service.startup == "":
                 startup = pebble.ServiceStartup.DISABLED
             else:
                 startup = pebble.ServiceStartup(service.startup)
-            info = pebble.ServiceInfo(name,
-                                      startup=startup,
-                                      current=pebble.ServiceStatus(status))
+            info = pebble.ServiceInfo(
+                name, startup=startup, current=pebble.ServiceStatus(status)
+            )
             infos[name] = info
         return infos
 
@@ -391,15 +391,15 @@ class Network(_DCBase):
 
     @classmethod
     def default(
-            cls,
-            name,
-            private_address: str = "1.1.1.1",
-            hostname: str = "",
-            cidr: str = "",
-            interface_name: str = "",
-            mac_address: Optional[str] = None,
-            egress_subnets=("1.1.1.2/32",),
-            ingress_addresses=("1.1.1.2",),
+        cls,
+        name,
+        private_address: str = "1.1.1.1",
+        hostname: str = "",
+        cidr: str = "",
+        interface_name: str = "",
+        mac_address: Optional[str] = None,
+        egress_subnets=("1.1.1.2/32",),
+        ingress_addresses=("1.1.1.2",),
     ) -> "Network":
         """Helper to create a minimal, heavily defaulted Network."""
         return cls(
@@ -421,6 +421,7 @@ class Network(_DCBase):
 @dataclasses.dataclass
 class _EntityStatus(_DCBase):
     """This class represents StatusBase and should not be interacted with directly."""
+
     # Why not use StatusBase directly? Because that's not json-serializable.
 
     name: str
@@ -428,12 +429,16 @@ class _EntityStatus(_DCBase):
 
     def __eq__(self, other):
         if isinstance(other, Tuple):
-            logger.warning('Comparing Status with Tuples is deprecated and will be removed soon.')
+            logger.warning(
+                "Comparing Status with Tuples is deprecated and will be removed soon."
+            )
             return (self.name, self.message) == other
         if isinstance(other, StatusBase):
             return (self.name, self.message) == (other.name, other.message)
-        logger.warning(f'Comparing Status with {other} is not stable and will be forbidden soon.'
-                       f'Please compare with StatusBase directly.')
+        logger.warning(
+            f"Comparing Status with {other} is not stable and will be forbidden soon."
+            f"Please compare with StatusBase directly."
+        )
         return super().__eq__(other)
 
     @classmethod
@@ -461,9 +466,11 @@ class Status(_DCBase):
             elif isinstance(val, StatusBase):
                 setattr(self, name, _EntityStatus._from_statusbase(val))
             elif isinstance(val, tuple):
-                logger.warning('Initializing Status.[app/unit] with Tuple[str, str] is deprecated '
-                               'and will be removed soon. \n'
-                               f'Please pass a StatusBase instance: `StatusBase(*{val})`')
+                logger.warning(
+                    "Initializing Status.[app/unit] with Tuple[str, str] is deprecated "
+                    "and will be removed soon. \n"
+                    f"Please pass a StatusBase instance: `StatusBase(*{val})`"
+                )
                 setattr(self, name, _EntityStatus(*val))
             else:
                 raise TypeError(f"Invalid status.{name}: {val!r}")
@@ -487,7 +494,9 @@ class StoredState(_DCBase):
 
 @dataclasses.dataclass
 class State(_DCBase):
-    config: Dict[str, Union[str, int, float, bool]] = dataclasses.field(default_factory=dict)
+    config: Dict[str, Union[str, int, float, bool]] = dataclasses.field(
+        default_factory=dict
+    )
     relations: List[Relation] = dataclasses.field(default_factory=list)
     networks: List[Network] = dataclasses.field(default_factory=list)
     containers: List[Container] = dataclasses.field(default_factory=list)
@@ -693,11 +702,11 @@ class Event(_DCBase):
 
 
 def deferred(
-        event: Union[str, Event],
-        handler: Callable,
-        event_id: int = 1,
-        relation: "Relation" = None,
-        container: "Container" = None,
+    event: Union[str, Event],
+    handler: Callable,
+    event_id: int = 1,
+    relation: "Relation" = None,
+    container: "Container" = None,
 ):
     """Construct a DeferredEvent from an Event or an event name."""
     if isinstance(event, str):
@@ -742,6 +751,7 @@ def _derive_args(event_name: str):
             args.append(InjectRelation(relation_name=event_name[: -len(term)]))
 
     return tuple(args)
+
 
 # todo: consider
 #  def get_containers_from_metadata(CharmType, can_connect: bool = False) -> List[Container]:

--- a/tests/test_e2e/test_pebble.py
+++ b/tests/test_e2e/test_pebble.py
@@ -157,8 +157,8 @@ PS = """
 @pytest.mark.parametrize(
     "cmd, out",
     (
-            ("ls", LS),
-            ("ps", PS),
+        ("ls", LS),
+        ("ps", PS),
     ),
 )
 def test_exec(charm_cls, cmd, out):
@@ -249,7 +249,7 @@ def test_pebble_plan(charm_cls, starting_service_status):
             "fooserv": pebble.ServiceStatus.ACTIVE,
             # todo: should we disallow setting status for services that aren't known YET?
             "barserv": starting_service_status,
-        }
+        },
     )
 
     out = State(containers=[container]).trigger(
@@ -262,10 +262,11 @@ def test_pebble_plan(charm_cls, starting_service_status):
     serv = lambda name, obj: pebble.Service(name, raw=obj)
     container = out.containers[0]
     assert container.plan.services == {
-        'barserv': serv('barserv', {'startup': 'disabled'}),
-        'fooserv': serv('fooserv', {'startup': 'enabled'})}
-    assert container.services['fooserv'].current == pebble.ServiceStatus.ACTIVE
-    assert container.services['fooserv'].startup == pebble.ServiceStartup.ENABLED
+        "barserv": serv("barserv", {"startup": "disabled"}),
+        "fooserv": serv("fooserv", {"startup": "enabled"}),
+    }
+    assert container.services["fooserv"].current == pebble.ServiceStatus.ACTIVE
+    assert container.services["fooserv"].startup == pebble.ServiceStartup.ENABLED
 
-    assert container.services['barserv'].current == pebble.ServiceStatus.ACTIVE
-    assert container.services['barserv'].startup == pebble.ServiceStartup.DISABLED
+    assert container.services["barserv"].current == pebble.ServiceStatus.ACTIVE
+    assert container.services["barserv"].startup == pebble.ServiceStartup.DISABLED


### PR DESCRIPTION
This PR makes it possible to run assertions on the unit/app status using ops.model.StatusBase instances.

Before:
`assert state.status.unit == ('active', 'foo')`

Now:
`assert state.status.unit == ActiveStatus('foo')`

The implementation relies on a private `_EntityStatus` object to avoid having `StatusBase` instances hanging around in the State, avoiding headaches when it comes to serializing/deserializing it. The user-facing API is therefore all based on familiar StatusBase subclasses, while the internals remain ops-unaware, which is good.

The change is backwards-compatible, and some warnings are popped whenever the user attempts to do Tuple[str,str] comparison with _EntityStatus, to nudge a transition to comparing with StatusBase directly.