### PR TITLE
Status history

### DIFF
--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -148,20 +148,14 @@ class _MockModelBackend(_ModelBackend):
         return network.hook_tool_output_fmt()
 
     # setter methods: these can mutate the state.
-    def application_version_set(self, *args, **kwargs):
-        self._state.status.app_version = args[0]
-        return None
+    def application_version_set(self, version: str):
+        self._state.status._update_app_version(version)  # noqa
 
-    def status_set(self, *args, **kwargs):
-        if kwargs.get("is_app"):
-            self._state.status.app = args
-        else:
-            self._state.status.unit = args
-        return None
+    def status_set(self, status: str, message: str = "", *, is_app: bool = False):
+        self._state.status._update_status(status, message, is_app)  # noqa
 
     def juju_log(self, level: str, message: str):
         self._state.juju_log.append((level, message))
-        return None
 
     def relation_set(self, relation_id: int, key: str, value: str, is_app: bool):
         relation = self._get_relation_by_id(relation_id)

--- a/tests/test_e2e/test_play_assertions.py
+++ b/tests/test_e2e/test_play_assertions.py
@@ -44,7 +44,7 @@ def test_charm_heals_on_start(mycharm):
     mycharm._call = call
 
     initial_state = State(
-        config={"foo": "bar"}, leader=True, status=Status(unit=("blocked", "foo"))
+        config={"foo": "bar"}, leader=True, status=Status(unit=BlockedStatus("foo"))
     )
 
     out = initial_state.trigger(
@@ -55,16 +55,26 @@ def test_charm_heals_on_start(mycharm):
         pre_event=pre_event,
     )
 
-    assert out.status.unit == ("active", "yabadoodle")
+    assert out.status.unit == ActiveStatus("yabadoodle")
 
     out.juju_log = []  # exclude juju log from delta
     out.stored_state = initial_state.stored_state  # ignore stored state in delta.
     assert out.jsonpatch_delta(initial_state) == [
         {
             "op": "replace",
-            "path": "/status/unit",
-            "value": ("active", "yabadoodle"),
-        }
+            "path": "/status/unit/message",
+            "value": "yabadoodle",
+        },
+        {
+            "op": "replace",
+            "path": "/status/unit/name",
+            "value": "active",
+        },
+        {
+            "op": "add",
+            "path": "/status/unit_history/0",
+            "value": {"message": "foo", "name": "blocked"},
+        },
     ]
 
 

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -4,7 +4,7 @@ import pytest
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, Framework
 
-from scenario.state import Event, Relation, State, _CharmSpec
+from scenario.state import Relation, State
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_e2e/test_state.py
+++ b/tests/test_e2e/test_state.py
@@ -89,23 +89,27 @@ def test_status_setting(state, mycharm):
         mycharm,
         meta={"name": "foo"},
     )
-    assert out.status.unit == ("active", "foo test")
-    assert out.status.app == ("waiting", "foo barz")
+    assert out.status.unit == ActiveStatus("foo test")
+    assert out.status.app == WaitingStatus("foo barz")
     assert out.status.app_version == ""
 
     out.juju_log = []  # ignore logging output in the delta
     out.stored_state = state.stored_state  # ignore stored state in delta.
     assert out.jsonpatch_delta(state) == sort_patch(
         [
+            {"op": "replace", "path": "/status/app/message", "value": "foo barz"},
+            {"op": "replace", "path": "/status/app/name", "value": "waiting"},
             {
-                "op": "replace",
-                "path": "/status/app",
-                "value": ("waiting", "foo barz"),
+                "op": "add",
+                "path": "/status/app_history/0",
+                "value": {"message": "", "name": "unknown"},
             },
+            {"op": "replace", "path": "/status/unit/message", "value": "foo test"},
+            {"op": "replace", "path": "/status/unit/name", "value": "active"},
             {
-                "op": "replace",
-                "path": "/status/unit",
-                "value": ("active", "foo test"),
+                "op": "add",
+                "path": "/status/unit_history/0",
+                "value": {"message": "", "name": "unknown"},
             },
         ]
     )

--- a/tests/test_e2e/test_status.py
+++ b/tests/test_e2e/test_status.py
@@ -1,0 +1,73 @@
+import pytest
+from ops.charm import CharmBase
+from ops.framework import Framework
+from ops.model import ActiveStatus, BlockedStatus, UnknownStatus, WaitingStatus
+
+from scenario.state import State, Status
+
+
+@pytest.fixture(scope="function")
+def mycharm():
+    class MyCharm(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            for evt in self.on.events().values():
+                self.framework.observe(evt, self._on_event)
+
+        def _on_event(self, event):
+            pass
+
+    return MyCharm
+
+
+def test_initial_status(mycharm):
+    def post_event(charm: CharmBase):
+        assert charm.unit.status == UnknownStatus()
+
+    out = State(leader=True).trigger(
+        "update-status", mycharm, meta={"name": "local"}, post_event=post_event
+    )
+
+    assert out.status.unit == UnknownStatus()
+
+
+def test_status_history(mycharm):
+    def post_event(charm: CharmBase):
+        for obj in [charm.unit, charm.app]:
+            obj.status = ActiveStatus("1")
+            obj.status = BlockedStatus("2")
+            obj.status = WaitingStatus("3")
+
+    out = State(leader=True).trigger(
+        "update-status", mycharm, meta={"name": "local"}, post_event=post_event
+    )
+
+    assert out.status.unit == WaitingStatus("3")
+    assert out.status.unit_history == [
+        UnknownStatus(),
+        ActiveStatus("1"),
+        BlockedStatus("2"),
+    ]
+
+    assert out.status.app == WaitingStatus("3")
+    assert out.status.app_history == [
+        UnknownStatus(),
+        ActiveStatus("1"),
+        BlockedStatus("2"),
+    ]
+
+
+def test_status_history_preservation(mycharm):
+    def post_event(charm: CharmBase):
+        for obj in [charm.unit, charm.app]:
+            obj.status = WaitingStatus("3")
+
+    out = State(
+        leader=True, status=Status(unit=ActiveStatus("foo"), app=ActiveStatus("bar"))
+    ).trigger("update-status", mycharm, meta={"name": "local"}, post_event=post_event)
+
+    assert out.status.unit == WaitingStatus("3")
+    assert out.status.unit_history == [ActiveStatus("foo")]
+
+    assert out.status.app == WaitingStatus("3")
+    assert out.status.app_history == [ActiveStatus("bar")]


### PR DESCRIPTION
Fixes #6 
Exposes API to assert that the charm transitioned through a sequence of statuses during its lifetime.

Suppose your charm does:
```python
from ops.model import MaintenanceStatus, ActiveStatus, WaitingStatus, BlockedStatus

# charm code:
def _on_event(self, _event):
    self.unit.status = MaintenanceStatus('determining who the ruler is...')
    try:
        if self._call_that_takes_a_few_seconds_and_only_passes_on_leadership:
            self.unit.status = ActiveStatus('I rule')
        else:
            self.unit.status = WaitingStatus('checking this is right...')
            self._check_that_takes_some_more_time()
            self.unit.status = ActiveStatus('I am ruled')
    except:
        self.unit.status = BlockedStatus('something went wrong')
```

You can verify that the charm has followed the expected path by checking the **unit status history** like so:

```python
from ops.model import MaintenanceStatus, ActiveStatus, WaitingStatus, UnknownStatus
from scenario import State

def test_statuses():
    out = State(leader=False).trigger(
        'start', 
        MyCharm,
        meta={"name": "foo"})
    assert out.status.unit_history == [
      UnknownStatus(),
      MaintenanceStatus('determining who the ruler is...'),
      WaitingStatus('checking this is right...'),
      ActiveStatus('I am ruled')
    ]
```
Note that, unless you initialize the State with a preexisting status, the first status in the history will always be `unknown`. That is because, so far as scenario is concerned, each event is "the first event this charm has ever seen".

