### PR TITLE
Consistency checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,5 @@ be overwritten by Scenario, and therefore ignored.
 
 
 # TODOS:
-- State-State consistency checks.
-- State-Metadata consistency checks.
 - When ops supports namespace packages, allow `pip install ops[scenario]` and nest the whole package under `/ops`.
 - Recorder

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Ops-Scenario
+Scenario
 ============
 
 This is a state transition testing framework for Operator Framework charms.
@@ -520,6 +520,25 @@ as verify its contents after the charm has run. Do keep in mind that the metadat
 be overwritten by Scenario, and therefore ignored.
 
 
+# Consistency checks
+
+A Scenario, that is, the combination of an event, a state, and a charm, is consistent if it's plausible in JujuLand.
+For example, Juju can't emit a `foo-relation-changed` event on your charm unless your charm has declared a `foo` relation
+endpoint in its `metadata.yaml`. If that happens, that's a juju bug.
+Scenario however assumes that Juju is bug-free, therefore, so far as we're concerned, that can't happen, and therefore we 
+help you verify that the scenarios you create are consistent and raise an exception if that isn't so.
+
+That happens automatically behind the scenes whenever you trigger an event; `scenario.consistency_checker.check_consistency`
+is called and verifies that the scenario makes sense.
+
+## Caveats:
+- False positives: not all checks are implemented yet; more will come.
+- False negatives: it is possible that a scenario you know to be consistent is seen as inconsistent. That is probably a bug in the consistency checker itself, please report it.
+- Inherent limitations: if you have a custom event whose name conflicts with a builtin one, the consistency constraints of the builtin one will apply. For example: if you decide to name your custom event `bar-pebble-ready`, but you are working on a machine charm or don't have either way a `bar` container in your `metadata.yaml`, Scenario will flag that as inconsistent. 
+
+## Bypassing the checker
+If you have a clear false negative, are explicitly testing 'edge', inconsistent situations, or for whatever reason the checker is in your way, you can set the `SCENARIO_SKIP_CONSISTENCY_CHECKS` envvar and skip it altogether. Hopefully you don't need that.
+
+
 # TODOS:
-- When ops supports namespace packages, allow `pip install ops[scenario]` and nest the whole package under `/ops`.
 - Recorder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "2.1.2.4"
+version = "2.1.2.5"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]

--- a/scenario/__init__.py
+++ b/scenario/__init__.py
@@ -1,2 +1,3 @@
+from scenario.consistency_checker import check_consistency
 from scenario.runtime import trigger
 from scenario.state import *

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -1,0 +1,212 @@
+import os
+from typing import TYPE_CHECKING, Iterable, NamedTuple, Tuple
+
+from scenario.runtime import InconsistentScenarioError
+from scenario.runtime import logger as scenario_logger
+from scenario.state import _CharmSpec, normalize_name
+
+if TYPE_CHECKING:
+    from scenario.state import Event, State
+
+logger = scenario_logger.getChild("consistency_checker")
+
+
+class Results(NamedTuple):
+    """Consistency checkers return type."""
+
+    errors: Iterable[str]
+    warnings: Iterable[str]
+
+
+def check_consistency(
+    state: "State",
+    event: "Event",
+    charm_spec: "_CharmSpec",
+    juju_version: str,
+):
+    """Validate the combination of a state, an event, a charm spec, and a juju version.
+
+    When invoked, it performs a series of checks that validate that the state is consistent with itself, with
+    the event being emitted, the charm metadata, etc...
+
+    This function performs some basic validation of the combination of inputs that goes into a scenario test and
+    determines if the scenario is a realistic/plausible/consistent one.
+
+    A scenario is inconsistent if it can practically never occur because it contradicts the juju model.
+    For example: juju guarantees that upon calling config-get, a charm will only ever get the keys it declared
+    in its config.yaml. So a State declaring some config keys that are not in the charm's config.yaml is nonsense,
+    and the combination of the two is inconsistent.
+    """
+    juju_version: Tuple[int, ...] = tuple(map(int, juju_version.split(".")))
+
+    if os.getenv("SCENARIO_SKIP_CONSISTENCY_CHECKS"):
+        logger.info("skipping consistency checks.")
+        return
+
+    errors = []
+    warnings = []
+
+    for check in (
+        check_containers_consistency,
+        check_config_consistency,
+        check_event_consistency,
+        check_secrets_consistency,
+    ):
+        results = check(
+            state=state, event=event, charm_spec=charm_spec, juju_version=juju_version
+        )
+        errors.extend(results.errors)
+        warnings.extend(results.warnings)
+
+    if errors:
+        err_fmt = "\n".join(errors)
+        raise InconsistentScenarioError(
+            f"Inconsistent scenario. The following errors were found: {err_fmt}"
+        )
+    if warnings:
+        err_fmt = "\n".join(warnings)
+        logger.warning(
+            f"This scenario is probably inconsistent. Double check, and ignore this warning if you're sure. "
+            f"The following warnings were found: {err_fmt}"
+        )
+
+
+def check_event_consistency(
+    *, event: "Event", charm_spec: "_CharmSpec", **_kwargs
+) -> Results:
+    """Check the internal consistency of the Event data structure.
+
+    For example, it checks that a relation event has a relation instance, and that the relation endpoint
+    name matches the event prefix.
+    """
+    errors = []
+    warnings = []
+
+    # custom event: can't make assumptions about its name and its semantics
+    if not event._is_builtin_event(charm_spec):  # noqa
+        warnings.append(
+            "this is a custom event; if its name makes it look like a builtin one "
+            "(e.g. a relation event, or a workload event), you might get some false-negative "
+            "consistency checks."
+        )
+
+    if event._is_relation_event:  # noqa
+        if not event.relation:
+            errors.append(
+                "cannot construct a relation event without the relation instance. "
+                "Please pass one."
+            )
+        else:
+            if not event.name.startswith(normalize_name(event.relation.endpoint)):
+                errors.append(
+                    f"relation event should start with relation endpoint name. {event.name} does "
+                    f"not start with {event.relation.endpoint}."
+                )
+
+    if event._is_workload_event:  # noqa
+        if not event.container:
+            errors.append(
+                "cannot construct a workload event without the container instance. "
+                "Please pass one."
+            )
+        else:
+            if not event.name.startswith(normalize_name(event.container.name)):
+                errors.append(
+                    f"workload event should start with container name. {event.name} does "
+                    f"not start with {event.container.name}."
+                )
+    return Results(errors, warnings)
+
+
+def check_config_consistency(
+    *, state: "State", charm_spec: "_CharmSpec", **_kwargs
+) -> Results:
+    """Check the consistency of the state.config with the charm_spec.config (config.yaml)."""
+    state_config = state.config
+    meta_config = (charm_spec.config or {}).get("options", {})
+    errors = []
+
+    for key, value in state_config.items():
+        if key not in meta_config:
+            errors.append(
+                f"config option {key!r} in state.config but not specified in config.yaml."
+            )
+            continue
+
+        # todo unify with snapshot's when merged.
+        converters = {
+            "string": str,
+            "int": int,
+            "integer": int,  # fixme: which one is it?
+            "number": float,
+            "boolean": bool,
+            "attrs": NotImplemented,  # fixme: wot?
+        }
+
+        expected_type_name = meta_config[key].get("type", None)
+        if not expected_type_name:
+            errors.append(f"config.yaml invalid; option {key!r} has no 'type'.")
+            continue
+
+        expected_type = converters.get(expected_type_name)
+        if not isinstance(value, expected_type):
+            errors.append(
+                f"config invalid; option {key!r} should be of type {expected_type} "
+                f"but is of type {type(value)}."
+            )
+
+    return Results(errors, [])
+
+
+def check_secrets_consistency(
+    *, event: "Event", state: "State", juju_version: Tuple[int, ...], **_kwargs
+) -> Results:
+    """Check the consistency of Secret-related stuff."""
+    errors = []
+    if not event._is_secret_event:  # noqa
+        return Results(errors, [])
+
+    if not state.secrets:
+        errors.append(
+            "the event being processed is a secret event; but the state has no secrets."
+        )
+    elif juju_version < (3,):
+        errors.append(
+            f"secrets are not supported in the specified juju version {juju_version}. "
+            f"Should be at least 3.0."
+        )
+
+    return Results(errors, [])
+
+
+def check_containers_consistency(
+    *, state: "State", event: "Event", charm_spec: "_CharmSpec", **_kwargs
+) -> Results:
+    """Check the consistency of `state.containers` vs. `charm_spec.meta` (metadata.yaml/containers)."""
+    meta_containers = list(charm_spec.meta.get("containers", {}))
+    state_containers = [c.name for c in state.containers]
+    errors = []
+
+    # it's fine if you have containers in meta that are not in state.containers (yet), but it's not fine if:
+    # - you're processing a pebble-ready event and that container is not in state.containers or meta.containers
+    if event._is_workload_event:  # noqa
+        evt_container_name = event.name[: -len("-pebble-ready")]
+        if evt_container_name not in meta_containers:
+            errors.append(
+                f"the event being processed concerns container {evt_container_name!r}, but a container "
+                f"with that name is not declared in the charm metadata"
+            )
+        if evt_container_name not in state_containers:
+            errors.append(
+                f"the event being processed concerns container {evt_container_name!r}, but a container "
+                f"with that name is not present in the state. It's odd, but consistent, if it cannot "
+                f"connect; but it should at least be there."
+            )
+
+    # - a container in state.containers is not in meta.containers
+    if diff := (set(state_containers).difference(set(meta_containers))):
+        errors.append(
+            f"some containers declared in the state are not specified in metadata. That's not possible. "
+            f"Missing from metadata: {diff}."
+        )
+    return Results(errors, [])

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -48,7 +48,7 @@ class _MockExecProcess:
 
 class _MockModelBackend(_ModelBackend):
     def __init__(self, state: "State", event: "Event", charm_spec: "_CharmSpec"):
-        super().__init__(state.unit_name, state.model.name, state.model.uuid)
+        super().__init__()
         self._state = state
         self._event = event
         self._charm_spec = charm_spec
@@ -94,11 +94,11 @@ class _MockModelBackend(_ModelBackend):
 
     def relation_get(self, rel_id, obj_name, app):
         relation = self._get_relation_by_id(rel_id)
-        if app and obj_name == self._state.app_name:
+        if app and obj_name == self.app_name:
             return relation.local_app_data
         elif app:
             return relation.remote_app_data
-        elif obj_name == self._state.unit_name:
+        elif obj_name == self.unit_name:
             return relation.local_unit_data
         else:
             unit_id = obj_name.split("/")[-1]

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -1,0 +1,5 @@
+
+
+from scenario.runtime import ConsistencyChecker
+from scenario.state import State, Event, _CharmSpec
+

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -1,5 +1,153 @@
+import pytest
+from ops.charm import CharmBase
+
+from scenario.runtime import ConsistencyChecker, InconsistentScenarioError
+from scenario.state import (
+    RELATION_EVENTS_SUFFIX,
+    Container,
+    Event,
+    Relation,
+    Secret,
+    State,
+    _CharmSpec,
+)
 
 
-from scenario.runtime import ConsistencyChecker
-from scenario.state import State, Event, _CharmSpec
+class MyCharm(CharmBase):
+    pass
 
+
+def assert_inconsistent(state, event, spec, juju_version="3.0"):
+    cc = ConsistencyChecker(state, event, spec, juju_version)
+    with pytest.raises(InconsistentScenarioError):
+        cc.run()
+
+
+def assert_consistent(state, event, spec, juju_version="3.0"):
+    cc = ConsistencyChecker(state, event, spec, juju_version)
+    cc.run()
+
+
+def test_base():
+    state = State()
+    event = Event("update-status")
+    spec = _CharmSpec(MyCharm, {})
+    assert_consistent(state, event, spec)
+
+
+def test_workload_event_without_container():
+    assert_inconsistent(
+        State(),
+        Event("foo-pebble-ready", container=Container("foo")),
+        _CharmSpec(MyCharm, {}),
+    )
+    assert_consistent(
+        State(containers=[Container("foo")]),
+        Event("foo-pebble-ready", container=Container("foo")),
+        _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
+    )
+
+
+def test_container_meta_mismatch():
+    assert_inconsistent(
+        State(containers=[Container("bar")]),
+        Event("foo"),
+        _CharmSpec(MyCharm, {"containers": {"baz": {}}}),
+    )
+    assert_consistent(
+        State(containers=[Container("bar")]),
+        Event("foo"),
+        _CharmSpec(MyCharm, {"containers": {"bar": {}}}),
+    )
+
+
+def test_container_in_state_but_no_container_in_meta():
+    assert_inconsistent(
+        State(containers=[Container("bar")]), Event("foo"), _CharmSpec(MyCharm, {})
+    )
+    assert_consistent(
+        State(containers=[Container("bar")]),
+        Event("foo"),
+        _CharmSpec(MyCharm, {"containers": {"bar": {}}}),
+    )
+
+
+def test_evt_bad_container_name():
+    assert_inconsistent(
+        State(),
+        Event("foo-pebble-ready", container=Container("bar")),
+        _CharmSpec(MyCharm, {}),
+    )
+    assert_consistent(
+        State(containers=[Container("bar")]),
+        Event("bar-pebble-ready", container=Container("bar")),
+        _CharmSpec(MyCharm, {"containers": {"bar": {}}}),
+    )
+
+
+@pytest.mark.parametrize("suffix", RELATION_EVENTS_SUFFIX)
+def test_evt_bad_relation_name(suffix):
+    assert_inconsistent(
+        State(),
+        Event(f"foo{suffix}", relation=Relation("bar")),
+        _CharmSpec(MyCharm, {}),
+    )
+    assert_consistent(
+        State(relations=[Relation("bar")]),
+        Event(f"bar{suffix}", relation=Relation("bar")),
+        _CharmSpec(MyCharm, {"requires": {"bar": {"interface": "xxx"}}}),
+    )
+
+
+@pytest.mark.parametrize("suffix", RELATION_EVENTS_SUFFIX)
+def test_evt_no_relation(suffix):
+    assert_inconsistent(State(), Event("foo-relation-created"), _CharmSpec(MyCharm, {}))
+    assert_consistent(
+        State(relations=[Relation("bar")]),
+        Event(f"bar{suffix}", relation=Relation("bar")),
+        _CharmSpec(MyCharm, {"requires": {"bar": {"interface": "xxx"}}}),
+    )
+
+
+def test_config_key_missing_from_meta():
+    assert_inconsistent(
+        State(config={"foo": True}), Event("bar"), _CharmSpec(MyCharm, {})
+    )
+    assert_consistent(
+        State(config={"foo": True}),
+        Event("bar"),
+        _CharmSpec(MyCharm, {}, config={"options": {"foo": {"type": "boolean"}}}),
+    )
+
+
+def test_bad_config_option_type():
+    assert_inconsistent(
+        State(config={"foo": True}),
+        Event("bar"),
+        _CharmSpec(MyCharm, {}, config={"options": {"foo": {"type": "string"}}}),
+    )
+    assert_consistent(
+        State(config={"foo": True}),
+        Event("bar"),
+        _CharmSpec(MyCharm, {}, config={"options": {"foo": {"type": "boolean"}}}),
+    )
+
+
+@pytest.mark.parametrize("bad_v", ("1.0", "0", "1.2", "2.35.42", "2.99.99", "2.99"))
+def test_secrets_jujuv_bad(bad_v):
+    assert_inconsistent(
+        State(secrets=[Secret("secret:foo", {0: {"a": "b"}})]),
+        Event("bar"),
+        _CharmSpec(MyCharm, {}),
+        bad_v,
+    )
+
+
+@pytest.mark.parametrize("good_v", ("3.0", "3.1", "3", "3.33", "4", "100"))
+def test_secrets_jujuv_bad(good_v):
+    assert_consistent(
+        State(secrets=[Secret("secret:foo", {0: {"a": "b"}})]),
+        Event("bar"),
+        _CharmSpec(MyCharm, {}),
+        good_v,
+    )

--- a/tests/test_e2e/test_builtin_scenes.py
+++ b/tests/test_e2e/test_builtin_scenes.py
@@ -45,6 +45,9 @@ def test_builtin_scenes(mycharm):
 def test_builtin_scenes_template(mycharm):
     mycharm.require_config = True
     check_builtin_sequences(
-        mycharm, meta={"name": "foo"}, template_state=State(config={"foo": "bar"})
+        mycharm,
+        meta={"name": "foo"},
+        config={"options": {"foo": {"type": "string"}}},
+        template_state=State(config={"foo": "bar"}),
     )
     assert CHARM_CALLED == 12

--- a/tests/test_e2e/test_config.py
+++ b/tests/test_e2e/test_config.py
@@ -32,6 +32,7 @@ def test_config_get(mycharm):
         "update-status",
         mycharm,
         meta={"name": "foo"},
+        config={"options": {"foo": {"type": "string"}, "baz": {"type": "integer"}}},
         post_event=check_cfg,
     )
 
@@ -49,7 +50,10 @@ def test_config_get_default_from_meta(mycharm):
         mycharm,
         meta={"name": "foo"},
         config={
-            "options": {"baz": {"type": "integer", "default": 2}},
+            "options": {
+                "foo": {"type": "string"},
+                "baz": {"type": "integer", "default": 2},
+            },
         },
         post_event=check_cfg,
     )

--- a/tests/test_e2e/test_custom_event_triggers.py
+++ b/tests/test_e2e/test_custom_event_triggers.py
@@ -1,16 +1,17 @@
+import os
+
 import pytest
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource
 
 from scenario import State
+from scenario.runtime import InconsistentScenarioError
 
 
-class FooEvent(EventBase):
-    pass
+def test_custom_event_emitted():
+    class FooEvent(EventBase):
+        pass
 
-
-@pytest.fixture
-def mycharm():
     class MyCharmEvents(CharmEvents):
         foo = EventSource(FooEvent)
 
@@ -26,9 +27,36 @@ def mycharm():
         def _on_foo(self, e):
             MyCharm._foo_called = True
 
-    return MyCharm
+    State().trigger("foo", MyCharm, meta=MyCharm.META)
+    assert MyCharm._foo_called
 
 
-def test_custom_event_emitted(mycharm):
-    State().trigger("foo", mycharm, meta=mycharm.META)
-    assert mycharm._foo_called
+def test_funky_named_event_emitted():
+    class FooRelationChangedEvent(EventBase):
+        pass
+
+    class MyCharmEvents(CharmEvents):
+        foo_relation_changed = EventSource(FooRelationChangedEvent)
+
+    class MyCharm(CharmBase):
+        META = {"name": "mycharm"}
+        on = MyCharmEvents()
+        _foo_called = False
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.framework.observe(self.on.foo_relation_changed, self._on_foo)
+
+        def _on_foo(self, e):
+            MyCharm._foo_called = True
+
+    # we called our custom event like a builtin one. Trouble!
+    with pytest.raises(InconsistentScenarioError):
+        State().trigger("foo-relation-changed", MyCharm, meta=MyCharm.META)
+
+    assert not MyCharm._foo_called
+
+    os.environ["SCENARIO_SKIP_CONSISTENCY_CHECKS"] = "1"
+    State().trigger("foo-relation-changed", MyCharm, meta=MyCharm.META)
+    assert MyCharm._foo_called
+    os.unsetenv("SCENARIO_SKIP_CONSISTENCY_CHECKS")

--- a/tests/test_e2e/test_play_assertions.py
+++ b/tests/test_e2e/test_play_assertions.py
@@ -44,12 +44,13 @@ def test_charm_heals_on_start(mycharm):
     mycharm._call = call
 
     initial_state = State(
-        config={"foo": "bar"}, leader=True, status=Status(unit=("blocked", "foo"))
+        config={"foo": "bar"}, leader=True, status=Status(unit=BlockedStatus("foo"))
     )
 
     out = initial_state.trigger(
         charm_type=mycharm,
         meta={"name": "foo"},
+        config={"options": {"foo": {"type": "string"}}},
         event="start",
         post_event=post_event,
         pre_event=pre_event,

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -62,6 +62,7 @@ def test_get_relation(mycharm):
                 "zoo": {"interface": "zoo"},
             },
         },
+        config={"options": {"foo": {"type": "string"}}},
     )
 
 

--- a/tests/test_e2e/test_rubbish_events.py
+++ b/tests/test_e2e/test_rubbish_events.py
@@ -1,9 +1,11 @@
+import os
+
 import pytest
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, Framework, Object
 
 from scenario.ops_main_mock import NoObserverError
-from scenario.state import State
+from scenario.state import Container, State
 
 
 class QuxEvent(EventBase):
@@ -44,7 +46,16 @@ def mycharm():
 @pytest.mark.parametrize("evt_name", ("rubbish", "foo", "bar", "kazoo_pebble_ready"))
 def test_rubbish_event_raises(mycharm, evt_name):
     with pytest.raises(NoObserverError):
+
+        if evt_name.startswith("kazoo"):
+            os.environ["SCENARIO_SKIP_CONSISTENCY_CHECKS"] = "true"
+            # will whine about the container not being in state and meta; but if we put the container in meta,
+            # it will actually register an event!
+
         State().trigger(evt_name, mycharm, meta={"name": "foo"})
+
+        if evt_name.startswith("kazoo"):
+            os.environ["SCENARIO_SKIP_CONSISTENCY_CHECKS"] = "false"
 
 
 @pytest.mark.parametrize("evt_name", ("qux",))

--- a/tests/test_e2e/test_rubbish_events.py
+++ b/tests/test_e2e/test_rubbish_events.py
@@ -5,7 +5,7 @@ from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, Framework, Object
 
 from scenario.ops_main_mock import NoObserverError
-from scenario.state import Container, State
+from scenario.state import Container, Event, State, _CharmSpec
 
 
 class QuxEvent(EventBase):
@@ -49,8 +49,8 @@ def test_rubbish_event_raises(mycharm, evt_name):
 
         if evt_name.startswith("kazoo"):
             os.environ["SCENARIO_SKIP_CONSISTENCY_CHECKS"] = "true"
-            # will whine about the container not being in state and meta; but if we put the container in meta,
-            # it will actually register an event!
+            # else it will whine about the container not being in state and meta;
+            # but if we put the container in meta, it will actually register an event!
 
         State().trigger(evt_name, mycharm, meta={"name": "foo"})
 
@@ -68,3 +68,22 @@ def test_custom_events_pass(mycharm, evt_name):
 def test_custom_events_sub_raise(mycharm, evt_name):
     with pytest.raises(RuntimeError):
         State().trigger(evt_name, mycharm, meta={"name": "foo"})
+
+
+@pytest.mark.parametrize(
+    "evt_name, expected",
+    (
+        ("qux", False),
+        ("sub", False),
+        ("start", True),
+        ("install", True),
+        ("config-changed", True),
+        ("foo-relation-changed", True),
+        ("bar-relation-changed", False),
+    ),
+)
+def test_is_custom_event(mycharm, evt_name, expected):
+    spec = _CharmSpec(
+        charm_type=mycharm, meta={"name": "mycharm", "requires": {"foo": {}}}
+    )
+    assert Event(evt_name)._is_builtin_event(spec) is expected


### PR DESCRIPTION
Added a ConsistencyChecker class responsible for validating the combination of a state, an event, a charm spec, and a juju version.

Upon calling .run(), it performs a series of checks that validate that the state is consistent with itself, with
the event being emitted, the charm metadata, etc...
For example, if someone tries to emit a foo-pebble-ready but there is no container 'foo' in metadata or in State,
this is where we surface the issue.

For the reviewers: 
- does the .run() calling a sequence of check-methods make sense implementation and pattern-wise?