### PR TITLE
Upgrade to Relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,40 @@ def test_relation_data():
 # which is very idiomatic and superbly explicit. Noice.
 ```
 
+If you want to trigger relation events, the easiest way to do so is get a hold of the Relation instance and grab the event from one of its aptly-named properties:
+
+```python
+from scenario import Relation
+relation = Relation(endpoint="foo", interface="bar")
+changed_event = relation.changed_event
+joined_event = relation.joined_event
+# ...
+```
+
+This is in fact syntactic sugar for:
+```python
+from scenario import Relation, Event
+relation = Relation(endpoint="foo", interface="bar")
+changed_event = Event('foo-relation-changed', relation=relation)
+```
+
+The reason for this construction is that the event is associated with some relation-specific metadata, that Scenario needs to set up the process that will run `ops.main` with the right environment variables.
+
+### Additional event parameters
+All relation events have some additional metadata that does not belong in the Relation object, such as, for a relation-joined event, the name of the (remote) unit that is joining the relation. That is what determines what `ops.model.Unit` you get when you get `RelationJoinedEvent().unit` in an event handler.
+
+In order to supply this parameter, you will have to **call** the event object and pass as `remote_unit` the id of the remote unit that the event is about.
+
+```python
+from scenario import Relation, Event
+relation = Relation(endpoint="foo", interface="bar")
+remote_unit_2_is_joining_event = relation.joined_event(remote_unit=2)
+
+# which is syntactic sugar for:
+remote_unit_2_is_joining_event = Event('foo-relation-changed', relation=relation, relation_remote_unit_id=2)
+```
+
+
 ## Containers
 
 When testing a kubernetes charm, you can mock container interactions.

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ def test_relation_data():
 ```
 ## Relation types
 
-When you use `Relation`, you are specifying a 'normal' relation. But that is not the only type of relation. There are also
-peer relations and subordinate relations. While in the background the data model is the same, the data access rules and the consistency constraints on them are very different. For example, it does not make sense for a peer relation to have a different 'remote app' than its 'local app' is, because it's the same application.    
+When you use `Relation`, you are specifying a regular (conventional) relation. But that is not the only type of relation. There are also
+peer relations and subordinate relations. While in the background the data model is the same, the data access rules and the consistency constraints on them are very different. For example, it does not make sense for a peer relation to have a different 'remote app' than its 'local app', because it's the same application.    
 
 
 TODO: describe peer/sub API.
@@ -244,6 +244,9 @@ The reason for this construction is that the event is associated with some relat
 All relation events have some additional metadata that does not belong in the Relation object, such as, for a relation-joined event, the name of the (remote) unit that is joining the relation. That is what determines what `ops.model.Unit` you get when you get `RelationJoinedEvent().unit` in an event handler.
 
 In order to supply this parameter, you will have to **call** the event object and pass as `remote_unit_id` the id of the remote unit that the event is about.
+The reason that this parameter is not supplied to `Relation` but to relation events, is that the relation already ties 'this app' to some 'remote app' (cfr. the `Relation.remote_app_name` attr), but not to a specific unit. What remote unit this event is about is not a `State` concern but an `Event` one.  
+
+The `remote_unit_id` will default to the first ID found in the relation's `remote_unit_ids`, but if the test you are writing is close to that domain, you should probably override it and pass it manually.
 
 ```python
 from scenario import Relation, Event

--- a/README.md
+++ b/README.md
@@ -211,7 +211,13 @@ def test_relation_data():
 
 # which is very idiomatic and superbly explicit. Noice.
 ```
+## Relation types
 
+When you use `Relation`, you are specifying a 'normal' relation. But that is not the only type of relation. There are also
+peer relations and subordinate relations. While in the background the data model is the same, the data access rules and the consistency constraints on them are very different. For example, it does not make sense for a peer relation to have a different 'remote app' than its 'local app' is, because it's the same application.    
+
+
+## Triggering Relation Events
 If you want to trigger relation events, the easiest way to do so is get a hold of the Relation instance and grab the event from one of its aptly-named properties:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ When you use `Relation`, you are specifying a 'normal' relation. But that is not
 peer relations and subordinate relations. While in the background the data model is the same, the data access rules and the consistency constraints on them are very different. For example, it does not make sense for a peer relation to have a different 'remote app' than its 'local app' is, because it's the same application.    
 
 
+TODO: describe peer/sub API.
+
+
 ## Triggering Relation Events
 If you want to trigger relation events, the easiest way to do so is get a hold of the Relation instance and grab the event from one of its aptly-named properties:
 

--- a/README.md
+++ b/README.md
@@ -243,12 +243,12 @@ The reason for this construction is that the event is associated with some relat
 ### Additional event parameters
 All relation events have some additional metadata that does not belong in the Relation object, such as, for a relation-joined event, the name of the (remote) unit that is joining the relation. That is what determines what `ops.model.Unit` you get when you get `RelationJoinedEvent().unit` in an event handler.
 
-In order to supply this parameter, you will have to **call** the event object and pass as `remote_unit` the id of the remote unit that the event is about.
+In order to supply this parameter, you will have to **call** the event object and pass as `remote_unit_id` the id of the remote unit that the event is about.
 
 ```python
 from scenario import Relation, Event
 relation = Relation(endpoint="foo", interface="bar")
-remote_unit_2_is_joining_event = relation.joined_event(remote_unit=2)
+remote_unit_2_is_joining_event = relation.joined_event(remote_unit_id=2)
 
 # which is syntactic sugar for:
 remote_unit_2_is_joining_event = Event('foo-relation-changed', relation=relation, relation_remote_unit_id=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "2.1.3.3"
+version = "2.1.3.4"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -201,16 +201,17 @@ def check_relation_consistency(
     subs = list(filter(lambda x: isinstance(x, SubordinateRelation), state.relations))
 
     # check subordinate relation consistency
-    seen_sub_primaries = set()
-    sub: SubordinateRelation
-    for sub in subs:
-        sig = (sub.primary_name, sub.endpoint)
-        if sig in seen_sub_primaries:
-            errors.append(
-                "cannot have multiple subordinate relations on the same endpoint with the same primary."
-            )
-            break
-        seen_sub_primaries.add(sig)
+    # todo determine what this rule should be
+    # seen_sub_primaries = {}
+    # sub: SubordinateRelation
+    # for sub in subs:
+    #     if seen_primary := seen_sub_primaries.get(sub.endpoint):
+    #         if sub.primary_name != seen_primary.primary_name:
+    #             errors.append(
+    #                 "cannot have multiple subordinate relations on the same "
+    #                 "endpoint with different primaries."
+    #             )
+    #             break
 
     for sub in subs:
         # todo: verify that *this unit*'s id is not in {relation.remote_unit_id}

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Iterable, NamedTuple, Tuple
 
 from scenario.runtime import InconsistentScenarioError
 from scenario.runtime import logger as scenario_logger
-from scenario.state import _CharmSpec, normalize_name
+from scenario.state import SubordinateRelation, _CharmSpec, normalize_name
 
 if TYPE_CHECKING:
     from scenario.state import Event, State
@@ -51,6 +51,7 @@ def check_consistency(
         check_config_consistency,
         check_event_consistency,
         check_secrets_consistency,
+        check_relation_consistency,
     ):
         results = check(
             state=state, event=event, charm_spec=charm_spec, juju_version=juju_version
@@ -175,6 +176,19 @@ def check_secrets_consistency(
             f"secrets are not supported in the specified juju version {juju_version}. "
             f"Should be at least 3.0."
         )
+
+    return Results(errors, [])
+
+
+def check_relation_consistency(
+    *, state: "State", event: "Event", charm_spec: "_CharmSpec", **_kwargs
+) -> Results:
+    errors = []
+    for relation in state.relations:
+        if isinstance(relation, SubordinateRelation):
+            # todo: verify that this unit's id is not in:
+            # relation.remote_unit_id
+            pass
 
     return Results(errors, [])
 

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Iterable, NamedTuple, Tuple
 
 from scenario.runtime import InconsistentScenarioError
 from scenario.runtime import logger as scenario_logger
-from scenario.state import SubordinateRelation, _CharmSpec, normalize_name
+from scenario.state import SubordinateRelation, _CharmSpec, normalize_name, RelationType
 
 if TYPE_CHECKING:
     from scenario.state import Event, State
@@ -21,10 +21,10 @@ class Results(NamedTuple):
 
 
 def check_consistency(
-    state: "State",
-    event: "Event",
-    charm_spec: "_CharmSpec",
-    juju_version: str,
+        state: "State",
+        event: "Event",
+        charm_spec: "_CharmSpec",
+        juju_version: str,
 ):
     """Validate the combination of a state, an event, a charm spec, and a juju version.
 
@@ -49,11 +49,11 @@ def check_consistency(
     warnings = []
 
     for check in (
-        check_containers_consistency,
-        check_config_consistency,
-        check_event_consistency,
-        check_secrets_consistency,
-        check_relation_consistency,
+            check_containers_consistency,
+            check_config_consistency,
+            check_event_consistency,
+            check_secrets_consistency,
+            check_relation_consistency,
     ):
         results = check(
             state=state, event=event, charm_spec=charm_spec, juju_version=juju_version
@@ -75,7 +75,7 @@ def check_consistency(
 
 
 def check_event_consistency(
-    *, event: "Event", charm_spec: "_CharmSpec", **_kwargs
+        *, event: "Event", charm_spec: "_CharmSpec", **_kwargs
 ) -> Results:
     """Check the internal consistency of the Event data structure.
 
@@ -122,7 +122,7 @@ def check_event_consistency(
 
 
 def check_config_consistency(
-    *, state: "State", charm_spec: "_CharmSpec", **_kwargs
+        *, state: "State", charm_spec: "_CharmSpec", **_kwargs
 ) -> Results:
     """Check the consistency of the state.config with the charm_spec.config (config.yaml)."""
     state_config = state.config
@@ -162,7 +162,7 @@ def check_config_consistency(
 
 
 def check_secrets_consistency(
-    *, event: "Event", state: "State", juju_version: Tuple[int, ...], **_kwargs
+        *, event: "Event", state: "State", juju_version: Tuple[int, ...], **_kwargs
 ) -> Results:
     """Check the consistency of Secret-related stuff."""
     errors = []
@@ -183,20 +183,49 @@ def check_secrets_consistency(
 
 
 def check_relation_consistency(
-    *, state: "State", event: "Event", charm_spec: "_CharmSpec", **_kwargs
+        *, state: "State", event: "Event", charm_spec: "_CharmSpec", **_kwargs
 ) -> Results:
     errors = []
-    # check endpoint unicity
+    nonpeer_relations_meta = list(chain(charm_spec.meta.get("requires", {}).items(),
+                                        charm_spec.meta.get("provides", {}).items()))
+    peer_relations_meta = charm_spec.meta.get("peers", {}).items()
+    all_relations_meta = list(chain(nonpeer_relations_meta,
+                                    peer_relations_meta))
+
+    def _get_relations(r):
+        try:
+            return state.get_relations(r)
+        except ValueError:
+            return ()
+
+    # check relation types
+    for endpoint, _ in peer_relations_meta:
+        for relation in _get_relations(endpoint):
+            if relation.__type__ is not RelationType.peer:
+                errors.append(f"endpoint {endpoint} is a peer relation; "
+                              f"expecting relation to be of type PeerRelation, gotten {type(relation)}")
+
+    for endpoint, relation_meta in all_relations_meta:
+        expected_sub = relation_meta.get('scope', '') == 'container'
+        relations = _get_relations(endpoint)
+        for relation in relations:
+            is_sub = relation.__type__ is RelationType.subordinate
+            if is_sub and not expected_sub:
+                errors.append(f"endpoint {endpoint} is not a subordinate relation; "
+                              f"expecting relation to be of type Relation, "
+                              f"gotten {type(relation)}")
+            if expected_sub and not is_sub:
+                errors.append(f"endpoint {endpoint} is a subordinate relation; "
+                              f"expecting relation to be of type SubordinateRelation, "
+                              f"gotten {type(relation)}")
+
+    # check for duplicate endpoint names
     seen_endpoints = set()
-    for rel in chain(
-        charm_spec.meta.get("requires", ()),
-        charm_spec.meta.get("provides", ()),
-        charm_spec.meta.get("peers", ()),
-    ):
-        if rel in seen_endpoints:
+    for endpoint, relation_meta in all_relations_meta:
+        if endpoint in seen_endpoints:
             errors.append("duplicate endpoint name in metadata.")
             break
-        seen_endpoints.add(rel)
+        seen_endpoints.add(endpoint)
 
     subs = list(filter(lambda x: isinstance(x, SubordinateRelation), state.relations))
 
@@ -221,7 +250,7 @@ def check_relation_consistency(
 
 
 def check_containers_consistency(
-    *, state: "State", event: "Event", charm_spec: "_CharmSpec", **_kwargs
+        *, state: "State", event: "Event", charm_spec: "_CharmSpec", **_kwargs
 ) -> Results:
     """Check the consistency of `state.containers` vs. `charm_spec.meta` (metadata.yaml/containers)."""
     meta_containers = list(charm_spec.meta.get("containers", {}))

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -186,11 +186,9 @@ def check_relation_consistency(
     *, state: "State", event: "Event", charm_spec: "_CharmSpec", **_kwargs
 ) -> Results:
     errors = []
-    nonpeer_relations_meta = list(
-        chain(
-            charm_spec.meta.get("requires", {}).items(),
-            charm_spec.meta.get("provides", {}).items(),
-        )
+    nonpeer_relations_meta = chain(
+        charm_spec.meta.get("requires", {}).items(),
+        charm_spec.meta.get("provides", {}).items(),
     )
     peer_relations_meta = charm_spec.meta.get("peers", {}).items()
     all_relations_meta = list(chain(nonpeer_relations_meta, peer_relations_meta))
@@ -207,7 +205,7 @@ def check_relation_consistency(
             if relation.__type__ is not RelationType.peer:
                 errors.append(
                     f"endpoint {endpoint} is a peer relation; "
-                    f"expecting relation to be of type PeerRelation, gotten {type(relation)}"
+                    f"expecting relation to be of type PeerRelation, got {type(relation)}"
                 )
 
     for endpoint, relation_meta in all_relations_meta:
@@ -219,13 +217,13 @@ def check_relation_consistency(
                 errors.append(
                     f"endpoint {endpoint} is not a subordinate relation; "
                     f"expecting relation to be of type Relation, "
-                    f"gotten {type(relation)}"
+                    f"got {type(relation)}"
                 )
             if expected_sub and not is_sub:
                 errors.append(
-                    f"endpoint {endpoint} is a subordinate relation; "
+                    f"endpoint {endpoint} is not a subordinate relation; "
                     f"expecting relation to be of type SubordinateRelation, "
-                    f"gotten {type(relation)}"
+                    f"got {type(relation)}"
                 )
 
     # check for duplicate endpoint names
@@ -235,25 +233,6 @@ def check_relation_consistency(
             errors.append("duplicate endpoint name in metadata.")
             break
         seen_endpoints.add(endpoint)
-
-    subs = list(filter(lambda x: isinstance(x, SubordinateRelation), state.relations))
-
-    # check subordinate relation consistency
-    # todo determine what this rule should be
-    # seen_sub_primaries = {}
-    # sub: SubordinateRelation
-    # for sub in subs:
-    #     if seen_primary := seen_sub_primaries.get(sub.endpoint):
-    #         if sub.primary_name != seen_primary.primary_name:
-    #             errors.append(
-    #                 "cannot have multiple subordinate relations on the same "
-    #                 "endpoint with different primaries."
-    #             )
-    #             break
-
-    for sub in subs:
-        # todo: verify that *this unit*'s id is not in {relation.remote_unit_id}
-        pass
 
     return Results(errors, [])
 

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Iterable, NamedTuple, Tuple
 
 from scenario.runtime import InconsistentScenarioError
 from scenario.runtime import logger as scenario_logger
-from scenario.state import RelationType, SubordinateRelation, _CharmSpec, normalize_name
+from scenario.state import PeerRelation, SubordinateRelation, _CharmSpec, normalize_name
 
 if TYPE_CHECKING:
     from scenario.state import Event, State
@@ -202,7 +202,7 @@ def check_relation_consistency(
     # check relation types
     for endpoint, _ in peer_relations_meta:
         for relation in _get_relations(endpoint):
-            if relation.__type__ is not RelationType.peer:
+            if not isinstance(relation, PeerRelation):
                 errors.append(
                     f"endpoint {endpoint} is a peer relation; "
                     f"expecting relation to be of type PeerRelation, got {type(relation)}"
@@ -212,7 +212,7 @@ def check_relation_consistency(
         expected_sub = relation_meta.get("scope", "") == "container"
         relations = _get_relations(endpoint)
         for relation in relations:
-            is_sub = relation.__type__ is RelationType.subordinate
+            is_sub = isinstance(relation, SubordinateRelation)
             if is_sub and not expected_sub:
                 errors.append(
                     f"endpoint {endpoint} is not a subordinate relation; "

--- a/scenario/fs_mocks.py
+++ b/scenario/fs_mocks.py
@@ -1,0 +1,35 @@
+import pathlib
+from typing import Dict
+
+from ops.testing import _TestingFilesystem, _TestingStorageMount  # noqa
+
+
+# todo consider duplicating the filesystem on State.copy() to be able to diff and have true state snapshots
+class _MockStorageMount(_TestingStorageMount):
+    def __init__(self, location: pathlib.PurePosixPath, src: pathlib.Path):
+        """Creates a new simulated storage mount.
+
+        Args:
+            location: The path within simulated filesystem at which this storage will be mounted.
+            src: The temporary on-disk location where the simulated storage will live.
+        """
+        self._src = src
+        self._location = location
+
+        try:
+            # for some reason this fails if src exists, even though exists_ok=True.
+            super().__init__(location=location, src=src)
+        except FileExistsError:
+            pass
+
+
+class _MockFileSystem(_TestingFilesystem):
+    def __init__(self, mounts: Dict[str, _MockStorageMount]):
+        super().__init__()
+        self._mounts = mounts
+
+    def add_mount(self, *args, **kwargs):
+        raise NotImplementedError("Cannot mutate mounts; declare them all in State.")
+
+    def remove_mount(self, *args, **kwargs):
+        raise NotImplementedError("Cannot mutate mounts; declare them all in State.")

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -104,7 +104,6 @@ class _MockModelBackend(_ModelBackend):
         return f"secret:{id}"
 
     def relation_get(self, rel_id, obj_name, app):
-        # fixme: this WILL definitely bork with peer and sub relation types.
         relation = self._get_relation_by_id(rel_id)
         if app and obj_name == self.app_name:
             return relation.local_app_data

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -2,7 +2,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import datetime
-import pathlib
 import random
 from io import StringIO
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
@@ -10,9 +9,10 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 from ops import pebble
 from ops.model import SecretInfo, SecretRotate, _ModelBackend
 from ops.pebble import Client, ExecError
-from ops.testing import _TestingFilesystem, _TestingPebbleClient, _TestingStorageMount
+from ops.testing import _TestingPebbleClient
 
 from scenario.logger import logger as scenario_logger
+from scenario.state import PeerRelation
 
 if TYPE_CHECKING:
     from scenario.state import Container as ContainerSpec
@@ -113,19 +113,7 @@ class _MockModelBackend(_ModelBackend):
             return relation.local_unit_data
 
         unit_id = int(obj_name.split("/")[-1])
-
-        relation_type = getattr(relation, "__type__", "<no type>")
-        # todo replace with enum value once cyclic import is fixed
-        if relation_type == "regular":
-            return relation.remote_units_data[unit_id]
-        elif relation_type == "peer":
-            return relation.peers_data[unit_id]
-        elif relation_type == "subordinate":
-            return relation.remote_unit_data
-        else:
-            raise TypeError(
-                f"Invalid relation type for {relation}: {relation.__type__}"
-            )
+        return relation._get_databag_for_remote(unit_id)  # noqa
 
     def is_leader(self):
         return self._state.leader
@@ -143,23 +131,13 @@ class _MockModelBackend(_ModelBackend):
 
     def relation_list(self, relation_id: int) -> Tuple[str]:
         relation = self._get_relation_by_id(relation_id)
-        # todo replace with enum value once cyclic import is fixed
-        relation_type = getattr(relation, "__type__", "<no type>")
-        if relation_type == "regular":
-            return tuple(
-                f"{relation.remote_app_name}/{unit_id}"
-                for unit_id in relation.remote_unit_ids
-            )
-        elif relation_type == "peer":
-            return tuple(f"{self.app_name}/{unit_id}" for unit_id in relation.peers_ids)
 
-        elif relation_type == "subordinate":
-            return (f"{relation.primary_name}",)
-        else:
-            raise RuntimeError(
-                f"Invalid relation type: {relation_type}; should be one of "
-                f"scenario.state.RelationType"
-            )
+        if isinstance(relation, PeerRelation):
+            return tuple(f"{self.app_name}/{unit_id}" for unit_id in relation.peers_ids)
+        return tuple(
+            f"{relation._remote_app_name}/{unit_id}"  # noqa
+            for unit_id in relation._remote_unit_ids  # noqa
+        )
 
     def config_get(self):
         state_config = self._state.config
@@ -350,35 +328,6 @@ class _MockModelBackend(_ModelBackend):
 
     def planned_units(self, *args, **kwargs):
         raise NotImplementedError("planned_units")
-
-
-class _MockStorageMount(_TestingStorageMount):
-    def __init__(self, location: pathlib.PurePosixPath, src: pathlib.Path):
-        """Creates a new simulated storage mount.
-
-        Args:
-            location: The path within simulated filesystem at which this storage will be mounted.
-            src: The temporary on-disk location where the simulated storage will live.
-        """
-        self._src = src
-        self._location = location
-        if (
-            not src.exists()
-        ):  # we need to add this guard because the directory might exist already.
-            src.mkdir(exist_ok=True, parents=True)
-
-
-# todo consider duplicating the filesystem on State.copy() to be able to diff and have true state snapshots
-class _MockFileSystem(_TestingFilesystem):
-    def __init__(self, mounts: Dict[str, _MockStorageMount]):
-        super().__init__()
-        self._mounts = mounts
-
-    def add_mount(self, *args, **kwargs):
-        raise NotImplementedError("Cannot mutate mounts; declare them all in State.")
-
-    def remove_mount(self, *args, **kwargs):
-        raise NotImplementedError("Cannot mutate mounts; declare them all in State.")
 
 
 class _MockPebbleClient(_TestingPebbleClient):

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -130,7 +130,7 @@ class _MockModelBackend(_ModelBackend):
             if rel.endpoint == relation_name
         ]
 
-    def relation_list(self, relation_id: int):
+    def relation_list(self, relation_id: int) -> Tuple[str]:
         relation = self._get_relation_by_id(relation_id)
         relation_type = getattr(relation, "__type__", "<no type>")
         if relation_type == "regular":
@@ -142,7 +142,7 @@ class _MockModelBackend(_ModelBackend):
             return tuple(f"{self.app_name}/{unit_id}" for unit_id in relation.peers_ids)
 
         elif relation_type == "subordinate":
-            return tuple(f"{relation.primary_name}")
+            return f"{relation.primary_name}",
         else:
             raise RuntimeError(
                 f"Invalid relation type: {relation_type}; should be one of "

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -104,6 +104,7 @@ class _MockModelBackend(_ModelBackend):
         return f"secret:{id}"
 
     def relation_get(self, rel_id, obj_name, app):
+        # fixme: this WILL definitely bork with peer and sub relation types.
         relation = self._get_relation_by_id(rel_id)
         if app and obj_name == self.app_name:
             return relation.local_app_data

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -14,7 +14,6 @@ from ops.log import setup_root_logging
 from ops.main import CHARM_STATE_FILE, _Dispatcher, _emit_charm_event, _get_charm_dir
 
 from scenario.logger import logger as scenario_logger
-from scenario.mocking import _MockModelBackend
 
 if TYPE_CHECKING:
     from ops.testing import CharmType
@@ -38,6 +37,9 @@ def main(
     """Set up the charm and dispatch the observed event."""
     charm_class = charm_spec.charm_type
     charm_dir = _get_charm_dir()
+
+    from scenario.mocking import _MockModelBackend
+
     model_backend = _MockModelBackend(  # pyright: reportPrivateUsage=false
         state=state, event=event, charm_spec=charm_spec
     )

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -190,7 +190,7 @@ class Runtime:
 
             if event._is_relation_event:  # noqa
                 remote_unit_id = event.relation_remote_unit_id
-                if not remote_unit_id:
+                if remote_unit_id is None:  # don't check truthiness because it could be int(0)
                     if len(relation.remote_unit_ids) == 1:
                         remote_unit_id = relation.remote_unit_ids[0]
                         logger.info(
@@ -206,7 +206,7 @@ class Runtime:
                             "If that is the case, pass `remote_unit` to the Event constructor."
                         )
 
-                if remote_unit_id:
+                if remote_unit_id is not None:
                     remote_unit = f"{relation.remote_app_name}/{remote_unit_id}"
                     env["JUJU_REMOTE_UNIT"] = remote_unit
                     if event.name.endswith("_relation_departed"):

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -190,7 +190,9 @@ class Runtime:
 
             if event._is_relation_event:  # noqa
                 remote_unit_id = event.relation_remote_unit_id
-                if remote_unit_id is None:  # don't check truthiness because it could be int(0)
+                if (
+                    remote_unit_id is None
+                ):  # don't check truthiness because it could be int(0)
                     if len(relation.remote_unit_ids) == 1:
                         remote_unit_id = relation.remote_unit_ids[0]
                         logger.info(

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -168,6 +168,7 @@ class Runtime:
             # os.unsetenv does not work !?
             del os.environ[key]
 
+
     def _get_event_env(self, state: "State", event: "Event", charm_root: Path):
         if event.name.endswith("_action"):
             # todo: do we need some special metadata, or can we assume action names are always dashes?
@@ -229,15 +230,15 @@ class Runtime:
                     remote_unit_id = remote_unit_ids[0]
                     logger.info(
                         "there's only one remote unit, so we set JUJU_REMOTE_UNIT to it, "
-                        "but you probably should be parametrizing the event with `remote_unit` "
+                        "but you probably should be parametrizing the event with `remote_unit_id` "
                         "to be explicit."
                     )
                 else:
+                    remote_unit_id = remote_unit_ids[0]
                     logger.warning(
-                        "unable to determine remote unit ID; which means JUJU_REMOTE_UNIT will "
-                        "be unset and you might get error if charm code attempts to access "
-                        "`event.unit` in event handlers. \n"
-                        "If that is the case, pass `remote_unit` to the Event constructor."
+                        "remote unit ID unset, and multiple remote unit IDs are present; "
+                        "We will pick the first one and hope for the best. You should be passing "
+                        "`remote_unit_id` to the Event constructor."
                     )
 
             if remote_unit_id is not None:
@@ -410,7 +411,6 @@ class Runtime:
 
             logger.info(" - Clearing env")
             self._cleanup_env(env)
-            assert not os.getenv("JUJU_DEPARTING_UNIT")
 
             logger.info(" - closing storage")
             output_state = self._close_storage(output_state, temporary_charm_root)

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -145,6 +145,7 @@ class Runtime:
         charm_spec: "_CharmSpec",
         charm_root: Optional["PathLike"] = None,
         juju_version: str = "3.0.0",
+        unit_id: int = 0,
     ):
         self._charm_spec = charm_spec
         self._juju_version = juju_version
@@ -155,8 +156,8 @@ class Runtime:
             raise ValueError('invalid metadata: mandatory "name" field is missing.')
 
         self._app_name = app_name
-        # todo: consider parametrizing unit-id? cfr https://github.com/canonical/ops-scenario/issues/11
-        self._unit_name = f"{app_name}/0"
+        self._unit_id = unit_id
+        self._unit_name = f"{app_name}/{unit_id}"
 
     @staticmethod
     def _cleanup_env(env):
@@ -412,6 +413,7 @@ def trigger(
     config: Optional[Dict[str, Any]] = None,
     charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
     juju_version: str = "3.0",
+    unit_id: int = 0,
 ) -> "State":
     """Trigger a charm execution with an Event and a State.
 
@@ -433,6 +435,7 @@ def trigger(
     :arg config: charm config to use. Needs to be a valid config.yaml format (as a python dict).
         If none is provided, we will search for a ``config.yaml`` file in the charm root.
     :arg juju_version: Juju agent version to simulate.
+    :arg unit_id: The ID of the Juju unit that is charm execution is running on.
     :arg charm_root: virtual charm root the charm will be executed with.
         If the charm, say, expects a `./src/foo/bar.yaml` file present relative to the
         execution cwd, you need to use this. E.g.:
@@ -464,6 +467,7 @@ def trigger(
         charm_spec=spec,
         juju_version=juju_version,
         charm_root=charm_root,
+        unit_id=unit_id,
     )
 
     return runtime.exec(

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -168,7 +168,6 @@ class Runtime:
             # os.unsetenv does not work !?
             del os.environ[key]
 
-
     def _get_event_env(self, state: "State", event: "Event", charm_root: Path):
         if event.name.endswith("_action"):
             # todo: do we need some special metadata, or can we assume action names are always dashes?

--- a/scenario/sequences.py
+++ b/scenario/sequences.py
@@ -96,6 +96,7 @@ def check_builtin_sequences(
     template_state: State = None,
     pre_event: Optional[Callable[["CharmType"], None]] = None,
     post_event: Optional[Callable[["CharmType"], None]] = None,
+    unit_id: int = 0,
 ):
     """Test that all the builtin startup and teardown events can fire without errors.
 
@@ -124,4 +125,5 @@ def check_builtin_sequences(
             config=config,
             pre_event=pre_event,
             post_event=post_event,
+            unit_id=unit_id,
         )

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -846,6 +846,7 @@ class State(_DCBase):
         config: Optional[Dict[str, Any]] = None,
         charm_root: Optional["PathLike"] = None,
         juju_version: str = "3.0",
+        unit_id: int = 0,
     ) -> "State":
         """Fluent API for trigger. See runtime.trigger's docstring."""
         from scenario.runtime import trigger as _runtime_trigger
@@ -861,6 +862,7 @@ class State(_DCBase):
             config=config,
             charm_root=charm_root,
             juju_version=juju_version,
+            unit_id=unit_id,
         )
 
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -30,6 +30,8 @@ if typing.TYPE_CHECKING:
     from ops.testing import CharmType
 
     PathLike = Union[str, Path]
+    AnyRelation = Union["Relation", "PeerRelation", "SubordinateRelation"]
+
 
 logger = scenario_logger.getChild("state")
 
@@ -330,15 +332,14 @@ class Relation(RelationBase):
 @dataclasses.dataclass
 class SubordinateRelation(RelationBase):
     __type__ = RelationType.subordinate
+
+    # todo: consider renaming them to primary_*_data
     remote_app_data: Dict[str, str] = dataclasses.field(default_factory=dict)
     remote_unit_data: Dict[str, str] = dataclasses.field(default_factory=dict)
 
     # app name and ID of the primary that *this unit* is attached to.
     primary_app_name: str = "remote"
     primary_id: int = 0
-
-    # IDs of the peers. Consistency checks will validate that *this unit*'s ID is not in here.
-    peers_ids: List[int] = dataclasses.field(default_factory=list)
 
     @property
     def __databags__(self):
@@ -708,7 +709,7 @@ class State(_DCBase):
     config: Dict[str, Union[str, int, float, bool]] = dataclasses.field(
         default_factory=dict
     )
-    relations: List[Relation] = dataclasses.field(default_factory=list)
+    relations: List[RelationBase] = dataclasses.field(default_factory=list)
     networks: List[Network] = dataclasses.field(default_factory=list)
     containers: List[Container] = dataclasses.field(default_factory=list)
     status: Status = dataclasses.field(default_factory=Status)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -169,7 +169,7 @@ class ParametrizedEvent:
                 f"{self._category} event constructor."
             )
 
-        return Event(*self._args, *self._kwargs, relation_remote_unit=remote_unit)
+        return Event(*self._args, *self._kwargs, relation_remote_unit_id=remote_unit)
 
     def deferred(self, handler: Callable, event_id: int = 1) -> "DeferredEvent":
         return self().deferred(handler=handler, event_id=event_id)
@@ -889,13 +889,13 @@ class Event(_DCBase):
     #  - pebble?
     #  - action?
 
-    def __call__(self, remote_unit: Optional[int] = None) -> "Event":
-        if remote_unit and not self._is_relation_event:
+    def __call__(self, remote_unit_id: Optional[int] = None) -> "Event":
+        if remote_unit_id and not self._is_relation_event:
             raise ValueError(
-                "cannot pass param `remote_unit` to a "
+                "cannot pass param `remote_unit_id` to a "
                 "non-relation event constructor."
             )
-        return self.replace(relation_remote_unit_id=remote_unit)
+        return self.replace(relation_remote_unit_id=remote_unit_id)
 
     def __post_init__(self):
         if "-" in self.name:

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -709,7 +709,7 @@ class State(_DCBase):
     config: Dict[str, Union[str, int, float, bool]] = dataclasses.field(
         default_factory=dict
     )
-    relations: List[RelationBase] = dataclasses.field(default_factory=list)
+    relations: List["AnyRelation"] = dataclasses.field(default_factory=list)
     networks: List[Network] = dataclasses.field(default_factory=list)
     containers: List[Container] = dataclasses.field(default_factory=list)
     status: Status = dataclasses.field(default_factory=Status)
@@ -755,7 +755,14 @@ class State(_DCBase):
         except StopIteration as e:
             raise ValueError(f"container: {name}") from e
 
-    # FIXME: not a great way to obtain a delta, but is "complete" todo figure out a better way.
+    def get_relations(self, endpoint: str) -> Tuple["AnyRelation"]:
+        """Get relation from this State, based on an input relation or its endpoint name."""
+        try:
+            return tuple(filter(lambda c: c.endpoint == endpoint, self.relations))
+        except StopIteration as e:
+            raise ValueError(f"relation: {endpoint}") from e
+
+    # FIXME: not a great way to obtain a delta, but is "complete". todo figure out a better way.
     def jsonpatch_delta(self, other: "State"):
         try:
             import jsonpatch

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -198,7 +198,8 @@ class RelationBase(_DCBase):
     local_unit_data: Dict[str, str] = dataclasses.field(default_factory=dict)
 
     @property
-    def __databags__(self):
+    def _databags(self):
+        """Yield all databags in this relation."""
         yield self.local_app_data
         yield self.local_unit_data
 
@@ -206,9 +207,13 @@ class RelationBase(_DCBase):
         global _RELATION_IDS_CTR
         if self.relation_id == -1:
             _RELATION_IDS_CTR += 1
+            logger.info(
+                f"relation ID unset; automatically assigning {_RELATION_IDS_CTR}. "
+                f"If there are problems, pass one manually."
+            )
             self.relation_id = _RELATION_IDS_CTR
 
-        for databag in self.__databags__:
+        for databag in self._databags:
             self._validate_databag(databag)
 
     def _validate_databag(self, databag: dict):
@@ -316,7 +321,8 @@ class Relation(RelationBase):
     )
 
     @property
-    def __databags__(self):
+    def _databags(self):
+        """Yield all databags in this relation."""
         yield self.local_app_data
         yield self.local_unit_data
         yield self.remote_app_data
@@ -342,7 +348,8 @@ class SubordinateRelation(RelationBase):
     primary_id: int = 0
 
     @property
-    def __databags__(self):
+    def _databags(self):
+        """Yield all databags in this relation."""
         yield self.local_app_data
         yield self.local_unit_data
         yield self.remote_app_data
@@ -362,7 +369,8 @@ class PeerRelation(RelationBase):
     peers_ids: List[int] = dataclasses.field(default_factory=list)
 
     @property
-    def __databags__(self):
+    def _databags(self):
+        """Yield all databags in this relation."""
         yield self.local_app_data
         yield self.local_unit_data
         yield from self.peers_data.values()

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -7,10 +7,12 @@ from scenario.state import (
     RELATION_EVENTS_SUFFIX,
     Container,
     Event,
+    PeerRelation,
     Relation,
     Secret,
     State,
-    _CharmSpec, PeerRelation, SubordinateRelation,
+    SubordinateRelation,
+    _CharmSpec,
 )
 
 
@@ -158,44 +160,45 @@ def test_secrets_jujuv_bad(good_v):
 
 def test_peer_relation_consistency():
     assert_inconsistent(
-        State(relations=[Relation('foo')]),
+        State(relations=[Relation("foo")]),
         Event("bar"),
-        _CharmSpec(MyCharm, {
-            'peers': {'foo': {'interface': 'bar'}}
-        }),
+        _CharmSpec(MyCharm, {"peers": {"foo": {"interface": "bar"}}}),
     )
     assert_consistent(
-        State(relations=[PeerRelation('foo')]),
+        State(relations=[PeerRelation("foo")]),
         Event("bar"),
-        _CharmSpec(MyCharm, {
-            'peers': {'foo': {'interface': 'bar'}}
-        }),
+        _CharmSpec(MyCharm, {"peers": {"foo": {"interface": "bar"}}}),
     )
 
 
 def test_sub_relation_consistency():
     assert_inconsistent(
-        State(relations=[Relation('foo')]),
+        State(relations=[Relation("foo")]),
         Event("bar"),
-        _CharmSpec(MyCharm, {
-            'requires': {'foo': {'interface': 'bar', 'scope': 'container'}}
-        }),
+        _CharmSpec(
+            MyCharm, {"requires": {"foo": {"interface": "bar", "scope": "container"}}}
+        ),
     )
     assert_consistent(
-        State(relations=[SubordinateRelation('foo')]),
+        State(relations=[SubordinateRelation("foo")]),
         Event("bar"),
-        _CharmSpec(MyCharm, {
-            'requires': {'foo': {'interface': 'bar', 'scope': 'container'}}
-        }),
+        _CharmSpec(
+            MyCharm, {"requires": {"foo": {"interface": "bar", "scope": "container"}}}
+        ),
     )
 
 
 def test_relation_sub_inconsistent():
     assert_inconsistent(
-        State(relations=[SubordinateRelation('foo')]),
+        State(relations=[SubordinateRelation("foo")]),
         Event("bar"),
-        _CharmSpec(MyCharm, {
-            'requires': {'foo': {'interface': 'bar'}}
-        }),
+        _CharmSpec(MyCharm, {"requires": {"foo": {"interface": "bar"}}}),
     )
 
+
+def test_dupe_containers_inconsistent():
+    assert_inconsistent(
+        State(containers=[Container("foo"), Container("foo")]),
+        Event("bar"),
+        _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
+    )

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -10,7 +10,7 @@ from scenario.state import (
     Relation,
     Secret,
     State,
-    _CharmSpec,
+    _CharmSpec, PeerRelation, SubordinateRelation,
 )
 
 
@@ -154,3 +154,48 @@ def test_secrets_jujuv_bad(good_v):
         _CharmSpec(MyCharm, {}),
         good_v,
     )
+
+
+def test_peer_relation_consistency():
+    assert_inconsistent(
+        State(relations=[Relation('foo')]),
+        Event("bar"),
+        _CharmSpec(MyCharm, {
+            'peers': {'foo': {'interface': 'bar'}}
+        }),
+    )
+    assert_consistent(
+        State(relations=[PeerRelation('foo')]),
+        Event("bar"),
+        _CharmSpec(MyCharm, {
+            'peers': {'foo': {'interface': 'bar'}}
+        }),
+    )
+
+
+def test_sub_relation_consistency():
+    assert_inconsistent(
+        State(relations=[Relation('foo')]),
+        Event("bar"),
+        _CharmSpec(MyCharm, {
+            'requires': {'foo': {'interface': 'bar', 'scope': 'container'}}
+        }),
+    )
+    assert_consistent(
+        State(relations=[SubordinateRelation('foo')]),
+        Event("bar"),
+        _CharmSpec(MyCharm, {
+            'requires': {'foo': {'interface': 'bar', 'scope': 'container'}}
+        }),
+    )
+
+
+def test_relation_sub_inconsistent():
+    assert_inconsistent(
+        State(relations=[SubordinateRelation('foo')]),
+        Event("bar"),
+        _CharmSpec(MyCharm, {
+            'requires': {'foo': {'interface': 'bar'}}
+        }),
+    )
+

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -176,9 +176,12 @@ def test_relation_events_attrs(mycharm, evt_name, remote_app_name, remote_unit_i
     "remote_app_name",
     ("remote", "prometheus", "aodeok123"),
 )
-def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name):
+def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name, caplog):
     relation = Relation(
-        endpoint="foo", interface="foo", remote_app_name=remote_app_name
+        endpoint="foo",
+        interface="foo",
+        remote_app_name=remote_app_name,
+        remote_units_data={0: {}, 1: {}},  # 2 units
     )
 
     def callback(charm: CharmBase, event):
@@ -202,3 +205,5 @@ def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name):
             },
         },
     )
+
+    assert "unable to determine remote unit ID" in caplog.text

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -1,15 +1,13 @@
-import os
 from typing import Type
 
 import pytest
 from ops.charm import CharmBase, CharmEvents, RelationDepartedEvent
 from ops.framework import EventBase, Framework
 
-from scenario.runtime import InconsistentScenarioError
 from scenario.state import (
     PeerRelation,
     Relation,
-    RelationType,
+    RelationBase,
     State,
     StateValidationError,
     SubordinateRelation,
@@ -234,18 +232,6 @@ def test_relation_app_data_bad_types(mycharm, data):
 
 
 @pytest.mark.parametrize(
-    "relation, expected_type",
-    (
-        (Relation("a"), RelationType.regular),
-        (PeerRelation("b"), RelationType.peer),
-        (SubordinateRelation("b"), RelationType.subordinate),
-    ),
-)
-def test_relation_type(relation, expected_type):
-    assert relation.__type__ == expected_type
-
-
-@pytest.mark.parametrize(
     "evt_name",
     ("changed", "broken", "departed", "joined", "created"),
 )
@@ -299,3 +285,8 @@ def test_trigger_sub_relation(mycharm):
     State(relations=[sub1, sub2]).trigger(
         "update-status", mycharm, meta=meta, post_event=post_event
     )
+
+
+def test_cannot_instantiate_relationbase():
+    with pytest.raises(RuntimeError):
+        RelationBase("")

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -241,3 +241,29 @@ def test_relation_app_data_bad_types(mycharm, data):
 )
 def test_relation_type(relation, expected_type):
     assert relation.__type__ == expected_type
+
+
+@pytest.mark.parametrize(
+    "evt_name",
+    ("changed", "broken", "departed", "joined", "created"),
+)
+@pytest.mark.parametrize(
+    "relation",
+    (Relation("a"), PeerRelation("b"), SubordinateRelation("b")),
+)
+def test_relation_event_trigger(relation, evt_name, mycharm):
+    meta = {
+        "name": "mycharm",
+        "requires": {"a": {"interface": "i1"}},
+        "provides": {
+            "c": {
+                "interface": "i3",
+                # this is a subordinate relation.
+                "scope": "container",
+            }
+        },
+        "peers": {"b": {"interface": "i2"}},
+    }
+    state = State(relations=[relation]).trigger(
+        getattr(relation, evt_name + "_event"), mycharm, meta=meta
+    )

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -165,7 +165,7 @@ def test_relation_events_attrs(mycharm, evt_name, remote_app_name, remote_unit_i
             relation,
         ],
     ).trigger(
-        getattr(relation, f"{evt_name}_event")(remote_unit=remote_unit_id),
+        getattr(relation, f"{evt_name}_event")(remote_unit_id=remote_unit_id),
         mycharm,
         meta={
             "name": "local",
@@ -194,8 +194,8 @@ def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name, caplog):
 
     def callback(charm: CharmBase, event):
         assert event.app  # that's always present
-        assert not event.unit
-        assert not getattr(event, "departing_unit", False)
+        assert event.unit
+        assert (evt_name == 'departed') is bool(getattr(event, "departing_unit", False))
 
     mycharm._call = callback
 
@@ -214,7 +214,7 @@ def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name, caplog):
         },
     )
 
-    assert "unable to determine remote unit ID" in caplog.text
+    assert "remote unit ID unset, and multiple remote unit IDs are present" in caplog.text
 
 
 @pytest.mark.parametrize("data", (set(), {}, [], (), 1, 1.0, None, b""))
@@ -249,7 +249,7 @@ def test_relation_type(relation, expected_type):
 )
 @pytest.mark.parametrize(
     "relation",
-    (Relation("a"), PeerRelation("b"), SubordinateRelation("b")),
+    (Relation("a"), PeerRelation("b"), SubordinateRelation("c")),
 )
 def test_relation_event_trigger(relation, evt_name, mycharm):
     meta = {

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -195,7 +195,7 @@ def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name, caplog):
     def callback(charm: CharmBase, event):
         assert event.app  # that's always present
         assert event.unit
-        assert (evt_name == 'departed') is bool(getattr(event, "departing_unit", False))
+        assert (evt_name == "departed") is bool(getattr(event, "departing_unit", False))
 
     mycharm._call = callback
 
@@ -214,7 +214,9 @@ def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name, caplog):
         },
     )
 
-    assert "remote unit ID unset, and multiple remote unit IDs are present" in caplog.text
+    assert (
+        "remote unit ID unset, and multiple remote unit IDs are present" in caplog.text
+    )
 
 
 @pytest.mark.parametrize("data", (set(), {}, [], (), 1, 1.0, None, b""))

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -5,7 +5,8 @@ import pytest
 from ops.charm import CharmBase, CharmEvents, RelationDepartedEvent
 from ops.framework import EventBase, Framework
 
-from scenario.state import Relation, State
+from scenario.runtime import InconsistentScenarioError
+from scenario.state import Relation, State, StateValidationError
 
 
 @pytest.fixture(scope="function")
@@ -207,3 +208,17 @@ def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name, caplog):
     )
 
     assert "unable to determine remote unit ID" in caplog.text
+
+
+@pytest.mark.parametrize("data", (set(), {}, [], (), 1, 1.0, None, b""))
+def test_relation_unit_data_bad_types(mycharm, data):
+    with pytest.raises(StateValidationError):
+        relation = Relation(
+            endpoint="foo", interface="foo", remote_units_data={0: {"a": data}}
+        )
+
+
+@pytest.mark.parametrize("data", (set(), {}, [], (), 1, 1.0, None, b""))
+def test_relation_app_data_bad_types(mycharm, data):
+    with pytest.raises(StateValidationError):
+        relation = Relation(endpoint="foo", interface="foo", local_app_data={"a": data})

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -6,7 +6,14 @@ from ops.charm import CharmBase, CharmEvents, RelationDepartedEvent
 from ops.framework import EventBase, Framework
 
 from scenario.runtime import InconsistentScenarioError
-from scenario.state import Relation, State, StateValidationError
+from scenario.state import (
+    PeerRelation,
+    Relation,
+    RelationType,
+    State,
+    StateValidationError,
+    SubordinateRelation,
+)
 
 
 @pytest.fixture(scope="function")
@@ -222,3 +229,15 @@ def test_relation_unit_data_bad_types(mycharm, data):
 def test_relation_app_data_bad_types(mycharm, data):
     with pytest.raises(StateValidationError):
         relation = Relation(endpoint="foo", interface="foo", local_app_data={"a": data})
+
+
+@pytest.mark.parametrize(
+    "relation, expected_type",
+    (
+        (Relation("a"), RelationType.regular),
+        (PeerRelation("b"), RelationType.peer),
+        (SubordinateRelation("b"), RelationType.subordinate),
+    ),
+)
+def test_relation_type(relation, expected_type):
+    assert relation.__type__ == expected_type

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -135,7 +135,11 @@ def test_relation_events(mycharm, evt_name, remote_app_name):
     "remote_app_name",
     ("remote", "prometheus", "aodeok123"),
 )
-def test_relation_events_attrs(mycharm, evt_name, remote_app_name):
+@pytest.mark.parametrize(
+    "remote_unit_id",
+    (0, 1),
+)
+def test_relation_events_attrs(mycharm, evt_name, remote_app_name, remote_unit_id):
     relation = Relation(
         endpoint="foo", interface="foo", remote_app_name=remote_app_name
     )
@@ -153,7 +157,7 @@ def test_relation_events_attrs(mycharm, evt_name, remote_app_name):
             relation,
         ],
     ).trigger(
-        getattr(relation, f"{evt_name}_event")(remote_unit=1),
+        getattr(relation, f"{evt_name}_event")(remote_unit=remote_unit_id),
         mycharm,
         meta={
             "name": "local",

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -88,7 +88,8 @@ def test_event_emission():
 
 
 @pytest.mark.parametrize("app_name", ("foo", "bar-baz", "QuX2"))
-def test_unit_name(app_name):
+@pytest.mark.parametrize("unit_id", (1, 2, 42))
+def test_unit_name(app_name, unit_id):
     meta = {
         "name": app_name,
     }
@@ -100,9 +101,10 @@ def test_unit_name(app_name):
             my_charm_type,
             meta=meta,
         ),
+        unit_id=unit_id,
     )
 
     def post_event(charm: CharmBase):
-        assert charm.unit.name == f"{app_name}/0"
+        assert charm.unit.name == f"{app_name}/{unit_id}"
 
     runtime.exec(state=State(), event=Event("start"), post_event=post_event)

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands =
 
 
 [testenv:lint]
+skip_install=True
 description =  lint
 deps =
     coverage[toml]
@@ -41,6 +42,7 @@ commands =
 
 
 [testenv:fmt]
+skip_install=True
 description = Format code
 deps =
     black


### PR DESCRIPTION
This PR addresses several limitations of the existing Relation implementation:

# 1
we did not have enough data in the Event datastructure to mock the following relation-event-specific envvars
- `JUJU_UNIT_NAME`
- `JUJU_APP_NAME`
- `JUJU_DEPARTING_UNIT`    -- only for *-relation-departed


This PR adds that functionality and corresponding tests.

# 2 
We lacked facilities to correctly mock peer and subordinate relation types.
This PR adds two new types: `PeerRelation` and `SubordinateRelation` to address that need.
