### PR TITLE
frozen dataclasses for python 3.11 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "2.1.3.5"
+version = "2.2"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -220,7 +220,7 @@ class _MockModelBackend(_ModelBackend):
         if peek or refresh:
             revision = max(secret.contents.keys())
             if refresh:
-                secret.revision = revision
+                secret._set_revision(revision)
 
         return secret.contents[revision]
 
@@ -298,6 +298,10 @@ class _MockModelBackend(_ModelBackend):
         else:
             secret.contents.clear()
 
+    def relation_remote_app_name(self, relation_id: int):
+        relation = self._get_relation_by_id(relation_id)
+        return relation.remote_app_name
+
     # TODO:
     def action_set(self, *args, **kwargs):
         raise NotImplementedError("action_set")
@@ -313,9 +317,6 @@ class _MockModelBackend(_ModelBackend):
 
     def action_get(self):
         raise NotImplementedError("action_get")
-
-    def relation_remote_app_name(self, *args, **kwargs):
-        raise NotImplementedError("relation_remote_app_name")
 
     def resource_get(self, *args, **kwargs):
         raise NotImplementedError("resource_get")

--- a/tests/test_e2e/test_pebble.py
+++ b/tests/test_e2e/test_pebble.py
@@ -128,9 +128,8 @@ def test_fs_pull(charm_cls, make_dirs):
         assert file.read() == text
     else:
         # nothing has changed
-        out.juju_log = []
-        out.stored_state = state.stored_state  # ignore stored state in delta.
-        assert not out.jsonpatch_delta(state)
+        out_purged = out.replace(juju_log=[], stored_state=state.stored_state)
+        assert not out_purged.jsonpatch_delta(state)
 
 
 LS = """

--- a/tests/test_e2e/test_play_assertions.py
+++ b/tests/test_e2e/test_play_assertions.py
@@ -58,9 +58,8 @@ def test_charm_heals_on_start(mycharm):
 
     assert out.status.unit == ActiveStatus("yabadoodle")
 
-    out.juju_log = []  # exclude juju log from delta
-    out.stored_state = initial_state.stored_state  # ignore stored state in delta.
-    assert out.jsonpatch_delta(initial_state) == [
+    out_purged = out.replace(juju_log=[], stored_state=initial_state.stored_state)
+    assert out_purged.jsonpatch_delta(initial_state) == [
         {
             "op": "replace",
             "path": "/status/unit/message",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 envlist =
-    {py36,py37,py38}
+    {py36,py37,py38,py311}
     unit, lint
 isolated_build = True
 skip_missing_interpreters = True


### PR DESCRIPTION
Python 3.11 changed something that broke State's DCBase as it was frequently using other dataclasses as dataclass field default.
Worked around it by freezing all dataclasses in State; some tweaks here and there had to be made to work around the new constraint that all State dataclasses are immutable.

In the future we might want to refactor some flows for the dataclasses to be TRULY immutable instead of working around dataclasse's `__setattr__` check.