### PR TITLE
charm state initial prototype

### DIFF
--- a/scenario/charm_state.py
+++ b/scenario/charm_state.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import inspect
+from typing import Generic, TypeVar
+
+_M = TypeVar("_M")
+
+
+class CharmStateBackend(Generic[_M]):
+    # todo consider alternative names:
+    #  - interface?
+    #  - facade?
+
+    def _generate_model(self):
+        """use inspect to find all props and generate a model data structure."""
+        model = {}
+        prop: property
+        # todo exclude members from base class
+        for name, prop in inspect.getmembers(
+            type(self),
+            predicate=lambda o: isinstance(o, property),
+        ):
+            settable = bool(getattr(prop, "fset", False))
+            model[name] = settable
+
+        return model

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -824,6 +824,11 @@ class StoredState(_DCBase):
 
 
 @dataclasses.dataclass(frozen=True)
+class CharmState(_DCBase):
+    name: str = "state"
+
+
+@dataclasses.dataclass(frozen=True)
 class State(_DCBase):
     """Represents the juju-owned portion of a unit's state.
 
@@ -851,6 +856,8 @@ class State(_DCBase):
     # to this list.
     deferred: List["DeferredEvent"] = dataclasses.field(default_factory=list)
     stored_state: List["StoredState"] = dataclasses.field(default_factory=dict)
+
+    charm_state: Optional[CharmState] = None
 
     # todo:
     #  actions?

--- a/tests/test_charm_state.py
+++ b/tests/test_charm_state.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+
+import pytest
+from ops import CharmBase, Framework
+
+from scenario import Context
+from scenario.charm_state import CharmStateBackend
+from scenario.state import CharmState, State
+
+
+@dataclass(frozen=True)
+class MyState(CharmState):
+    foo: int = 10
+    bar: str = "10"
+
+
+class MyCharmStateBackend(CharmStateBackend):
+    @property
+    def foo(self) -> int:
+        return 10
+
+    @foo.setter
+    def foo(self, val: int):
+        pass
+
+    @property
+    def bar(self) -> str:
+        return "10"
+
+
+class MyCharm(CharmBase):
+    state = MyCharmStateBackend()
+
+    def __init__(self, framework: Framework):
+        super().__init__(framework)
+        self.foo = self.state.foo
+        self.bar = self.state.bar
+
+
+@pytest.fixture
+def ctx():
+    return Context(MyCharm, meta={"name": "foo"})
+
+
+@pytest.mark.parametrize("attr", ("foo", "bar"))
+@pytest.mark.parametrize("val", (1, 10, 20))
+def test_get(ctx, attr, val):
+    state = State(charm_state=MyState("state", val, str(val)))
+
+    def post_event(charm: MyCharm):
+        assert charm.foo == val
+        assert charm.bar == str(val)
+
+    ctx.run("start", state=state, post_event=post_event)


### PR DESCRIPTION
this PR adds to scenario charm-state mocking utilities.


# Charm State

Suppose that your charm code makes an http call to a server somewhere to get some data, say, the current temperature reading from a sensor on top of the Nieuwe Kerk in Delft, The Netherlands. 

If you follow the best practices of how to structure your charm code, then you are aware that this piece of data, at runtime, is categorised as 'charm state'. 
Scenario offers a way to plug into this system natively, and integrate this charm state data structure into its own `State` tree.

If your charm code looks like this:
```python
from dataclasses import dataclass
from ops import CharmBase, Framework

from scenario.charm_state import CharmStateBackend
from scenario.state import CharmState

# in state.py
@dataclass(frozen=True)
class MyState(CharmState):
    temperature: float = 4.5  # brr

# in state.py
class MyCharmStateBackend(CharmStateBackend):
    @property
    def temperature(self) -> int:
        import requests
        return requests.get('http://nieuwekerk.delft.nl/temp...').json()['celsius']
    
    # no setter: you can't change the weather. 
    # ... Can you?
    
# in charm.py
class MyCharm(CharmBase):
    state = MyCharmStateBackend()

    def __init__(self, framework: Framework):
        super().__init__(framework)
        self.temperature = self.state.temperature
```

Then you can write scenario tests like that:

```python
import pytest
from scenario import Context, State
from charm import MyCharm
from state import MyState

@pytest.fixture
def ctx():
    return Context(MyCharm, meta={"name": "foo"})


@pytest.mark.parametrize("temp", (1.1, 10.2, 20.3))
def test_get(ctx, temp):
    state = State(charm_state=MyState("state", temperature=temp))

    # the charm code will get the value from State.charm_state.temperature instead of making http calls at test-time.
    def post_event(charm: MyCharm):
        assert charm.temperature == temp

    ctx.run("start", state=state, post_event=post_event)
```
