### PR TITLE
[4.0] support for custom events

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,7 +874,7 @@ class MyCharmType(CharmBase):
 
 state = State(stored_state=[
     StoredState(
-        owner_path="MyCharmType",
+        event_owner_path="MyCharmType",
         name="my_stored_state",
         content={
             'foo': 'bar',
@@ -885,6 +885,32 @@ state = State(stored_state=[
 
 And the charm's runtime will see `self.stored_State.foo` and `.baz` as expected. Also, you can run assertions on it on
 the output side the same as any other bit of state.
+
+# Emitting custom events
+
+While the main use case of Scenario is to emit juju events, i.e. the built-in `start`, `install`, `*-relation-changed`, etc..., it can be sometimes handy to directly trigger custom events defined on arbitrary Objects in your hierarchy.
+
+Suppose your charm uses a charm library providing an `ingress_provided` event.
+The 'proper' way to emit it is to run the event that causes that custom event to be emitted by the library, whatever that may be, for example a `foo-relation-changed`.
+
+However, that may mean that you have to set up all sorts of State and mocks so that the right preconditions are met and the event is emitted at all.
+
+However if you attempt to run that event directly you will get an error:
+```python
+from scenario import Context, State
+Context(...).run("ingress_provided", State())  # raises scenario.ops_main_mock.NoObserverError
+```
+This happens because the framework, by default, searches for an event source named `ingress_provided` in `charm.on`, but since the event is defined on another Object, it will fail to find it.
+
+You can pass an `event_owner_path` argument to tell Scenario where to find the event source.
+
+```python
+from scenario import Context, State
+Context(...).run("ingress_provided", State(), event_owner_path=("my_charm_lib", "on"))
+```
+
+This will instruct Scenario to emit `my_charm.my_charm_lib.on.foo`.
+
 
 # The virtual charm root
 

--- a/README.md
+++ b/README.md
@@ -902,15 +902,16 @@ Context(...).run("ingress_provided", State())  # raises scenario.ops_main_mock.N
 ```
 This happens because the framework, by default, searches for an event source named `ingress_provided` in `charm.on`, but since the event is defined on another Object, it will fail to find it.
 
-You can pass an `event_owner_path` argument to tell Scenario where to find the event source.
+You can prefix the event name with the path leading to its owner to tell Scenario where to find the event source:
 
 ```python
 from scenario import Context, State
-Context(...).run("ingress_provided", State(), event_owner_path=("my_charm_lib", "on"))
+Context(...).run("my_charm_lib.on.ingress_provided", State())
 ```
 
 This will instruct Scenario to emit `my_charm.my_charm_lib.on.foo`.
 
+(always omit the 'root', i.e. the charm framework key, from the path)
 
 # The virtual charm root
 

--- a/README.md
+++ b/README.md
@@ -874,7 +874,7 @@ class MyCharmType(CharmBase):
 
 state = State(stored_state=[
     StoredState(
-        event_owner_path="MyCharmType",
+        owner_path="MyCharmType",
         name="my_stored_state",
         content={
             'foo': 'bar',

--- a/scenario/context.py
+++ b/scenario/context.py
@@ -2,17 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 from collections import namedtuple
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 
 from ops import EventBase
 
@@ -120,7 +110,6 @@ class Context:
         state: "State",
         pre_event: Optional[Callable[["CharmType"], None]] = None,
         post_event: Optional[Callable[["CharmType"], None]] = None,
-        event_owner_path: Sequence[str] = None,
     ) -> "State":
         """Trigger a charm execution with an Event and a State.
 
@@ -134,16 +123,8 @@ class Context:
             instantiated charm. Will receive the charm instance as only positional argument.
         :arg post_event: callback to be invoked right after emitting the event on the charm.
             Will receive the charm instance as only positional argument.
-        :arg event_owner_path: Path to the ``Object`` that owns this event. E.g. ('foo', 'bar') ->
-            will emit the event it can find at ``<CharmType>.foo.bar.on``.
         """
         """Validate the event and cast to Event."""
-        if isinstance(event_owner_path, str):
-            raise TypeError(
-                "event_owner_path cannot be a string, "
-                "it should be any other Sequence type of strings",
-            )
-
         if isinstance(event, str):
             event = Event(event)
 
@@ -161,7 +142,6 @@ class Context:
             state=state,
             pre_event=pre_event,
             post_event=post_event,
-            event_owner_path=event_owner_path,
         )
 
     def run_action(
@@ -220,7 +200,6 @@ class Context:
         state: "State",
         pre_event: Optional[Callable[["CharmType"], None]] = None,
         post_event: Optional[Callable[["CharmType"], None]] = None,
-        event_owner_path: Sequence[str] = None,
     ) -> "State":
         runtime = Runtime(
             charm_spec=self.charm_spec,
@@ -234,5 +213,4 @@ class Context:
             pre_event=pre_event,
             post_event=post_event,
             context=self,
-            event_owner_path=event_owner_path,
         )

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -53,7 +53,7 @@ def _get_owner(root: Any, path: Sequence[str]) -> ops.ObjectEvents:
 def _emit_charm_event(
     charm: "CharmBase",
     event_name: str,
-    event_owner_path: Sequence[str] = None,
+    event: "Event" = None,
 ):
     """Emits a charm event based on a Juju event name.
 
@@ -62,7 +62,7 @@ def _emit_charm_event(
         event_name: A Juju event name to emit on a charm.
         event_owner_path: Event source lookup path.
     """
-    owner = _get_owner(charm, event_owner_path) if event_owner_path else charm.on
+    owner = _get_owner(charm, event.owner_path) if event else charm.on
 
     try:
         event_to_emit = getattr(owner, event_name)
@@ -86,7 +86,6 @@ def main(
     event: "Event" = None,
     context: "Context" = None,
     charm_spec: "_CharmSpec" = None,
-    event_owner_path: Sequence[str] = None,
 ):
     """Set up the charm and dispatch the observed event."""
     charm_class = charm_spec.charm_type
@@ -141,7 +140,7 @@ def main(
         if pre_event:
             pre_event(charm)
 
-        _emit_charm_event(charm, dispatcher.event_name, event_owner_path)
+        _emit_charm_event(charm, dispatcher.event_name, event)
 
         if post_event:
             post_event(charm)

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -40,11 +40,11 @@ def _get_owner(root: Any, path: Sequence[str]) -> ops.ObjectEvents:
             obj = getattr(obj, step)
         except AttributeError:
             raise BadOwnerPath(
-                f"owner_path {path!r} invalid: {step!r} leads to nowhere.",
+                f"event_owner_path {path!r} invalid: {step!r} leads to nowhere.",
             )
     if not isinstance(obj, ops.ObjectEvents):
         raise BadOwnerPath(
-            f"owner_path {path!r} invalid: does not lead to "
+            f"event_owner_path {path!r} invalid: does not lead to "
             f"an ObjectEvents instance.",
         )
     return obj
@@ -53,16 +53,16 @@ def _get_owner(root: Any, path: Sequence[str]) -> ops.ObjectEvents:
 def _emit_charm_event(
     charm: "CharmBase",
     event_name: str,
-    owner_path: Sequence[str] = None,
+    event_owner_path: Sequence[str] = None,
 ):
     """Emits a charm event based on a Juju event name.
 
     Args:
         charm: A charm instance to emit an event from.
         event_name: A Juju event name to emit on a charm.
-        owner_path: Event source lookup path.
+        event_owner_path: Event source lookup path.
     """
-    owner = _get_owner(charm, owner_path) if owner_path else charm.on
+    owner = _get_owner(charm, event_owner_path) if event_owner_path else charm.on
 
     try:
         event_to_emit = getattr(owner, event_name)
@@ -86,7 +86,7 @@ def main(
     event: "Event" = None,
     context: "Context" = None,
     charm_spec: "_CharmSpec" = None,
-    owner_path: Sequence[str] = None,
+    event_owner_path: Sequence[str] = None,
 ):
     """Set up the charm and dispatch the observed event."""
     charm_class = charm_spec.charm_type
@@ -141,7 +141,7 @@ def main(
         if pre_event:
             pre_event(charm)
 
-        _emit_charm_event(charm, dispatcher.event_name, owner_path)
+        _emit_charm_event(charm, dispatcher.event_name, event_owner_path)
 
         if post_event:
             post_event(charm)

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -3,17 +3,19 @@
 # See LICENSE file for licensing details.
 import inspect
 import os
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
 
 import ops.charm
 import ops.framework
 import ops.model
 import ops.storage
+from ops import CharmBase
 from ops.charm import CharmMeta
 from ops.log import setup_root_logging
-from ops.main import CHARM_STATE_FILE, _Dispatcher, _emit_charm_event, _get_charm_dir
 
-from scenario.logger import logger as scenario_logger
+# use logger from ops.main so that juju_log will be triggered
+from ops.main import CHARM_STATE_FILE, _Dispatcher, _get_charm_dir, _get_event_args
+from ops.main import logger as ops_logger
 
 if TYPE_CHECKING:
     from ops.testing import CharmType
@@ -21,11 +23,60 @@ if TYPE_CHECKING:
     from scenario.context import Context
     from scenario.state import Event, State, _CharmSpec
 
-logger = scenario_logger.getChild("ops_main_mock")
-
 
 class NoObserverError(RuntimeError):
     """Error raised when the event being dispatched has no registered observers."""
+
+
+class BadOwnerPath(RuntimeError):
+    """Error raised when the owner path does not lead to a valid ObjectEvents instance."""
+
+
+def _get_owner(root: Any, path: Sequence[str]) -> ops.ObjectEvents:
+    """Walk path on root to an ObjectEvents instance."""
+    obj = root
+    for step in path:
+        try:
+            obj = getattr(obj, step)
+        except AttributeError:
+            raise BadOwnerPath(
+                f"owner_path {path!r} invalid: {step!r} leads to nowhere.",
+            )
+    if not isinstance(obj, ops.ObjectEvents):
+        raise BadOwnerPath(
+            f"owner_path {path!r} invalid: does not lead to "
+            f"an ObjectEvents instance.",
+        )
+    return obj
+
+
+def _emit_charm_event(
+    charm: "CharmBase",
+    event_name: str,
+    owner_path: Sequence[str] = None,
+):
+    """Emits a charm event based on a Juju event name.
+
+    Args:
+        charm: A charm instance to emit an event from.
+        event_name: A Juju event name to emit on a charm.
+        owner_path: Event source lookup path.
+    """
+    owner = _get_owner(charm, owner_path) if owner_path else charm.on
+
+    try:
+        event_to_emit = getattr(owner, event_name)
+    except AttributeError:
+        ops_logger.debug("Event %s not defined for %s.", event_name, charm)
+        raise NoObserverError(
+            f"Cannot fire {event_name!r} on {owner}: "
+            f"invalid event (not on charm.on). "
+            f"Use Context.run_custom instead.",
+        )
+
+    args, kwargs = _get_event_args(charm, event_to_emit)
+    ops_logger.debug("Emitting Juju event %s.", event_name)
+    event_to_emit.emit(*args, **kwargs)
 
 
 def main(
@@ -35,6 +86,7 @@ def main(
     event: "Event" = None,
     context: "Context" = None,
     charm_spec: "_CharmSpec" = None,
+    owner_path: Sequence[str] = None,
 ):
     """Set up the charm and dispatch the observed event."""
     charm_class = charm_spec.charm_type
@@ -50,7 +102,7 @@ def main(
     )
     debug = "JUJU_DEBUG" in os.environ
     setup_root_logging(model_backend, debug=debug)
-    logger.debug(
+    ops_logger.debug(
         "Operator Framework %s up and running.",
         ops.__version__,
     )  # type:ignore
@@ -89,14 +141,7 @@ def main(
         if pre_event:
             pre_event(charm)
 
-        if not getattr(charm.on, dispatcher.event_name, None):
-            raise NoObserverError(
-                f"Cannot fire {dispatcher.event_name!r} on {charm}: "
-                f"invalid event (not on charm.on). "
-                f"This is probably not what you were looking for.",
-            )
-
-        _emit_charm_event(charm, dispatcher.event_name)
+        _emit_charm_event(charm, dispatcher.event_name, owner_path)
 
         if post_event:
             post_event(charm)

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 logger = scenario_logger.getChild("runtime")
 STORED_STATE_REGEX = re.compile(
-    r"((?P<owner_path>.*)\/)?(?P<data_type_name>\D+)\[(?P<name>.*)\]",
+    r"((?P<event_owner_path>.*)\/)?(?P<data_type_name>\D+)\[(?P<name>.*)\]",
 )
 EVENT_REGEX = re.compile(_event_regex)
 
@@ -333,7 +333,7 @@ class Runtime:
         context: "Context",
         pre_event: Optional[Callable[["CharmType"], None]] = None,
         post_event: Optional[Callable[["CharmType"], None]] = None,
-        owner_path: Sequence[str] = None,
+        event_owner_path: Sequence[str] = None,
     ) -> "State":
         """Runs an event with this state as initial state on a charm.
 
@@ -388,7 +388,7 @@ class Runtime:
                     charm_spec=self._charm_spec.replace(
                         charm_type=self._wrap(charm_type),
                     ),
-                    owner_path=owner_path,
+                    event_owner_path=event_owner_path,
                 )
             except NoObserverError:
                 raise  # propagate along

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -14,6 +14,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Type,
     TypeVar,
     Union,
@@ -332,6 +333,7 @@ class Runtime:
         context: "Context",
         pre_event: Optional[Callable[["CharmType"], None]] = None,
         post_event: Optional[Callable[["CharmType"], None]] = None,
+        owner_path: Sequence[str] = None,
     ) -> "State":
         """Runs an event with this state as initial state on a charm.
 
@@ -386,6 +388,7 @@ class Runtime:
                     charm_spec=self._charm_spec.replace(
                         charm_type=self._wrap(charm_type),
                     ),
+                    owner_path=owner_path,
                 )
             except NoObserverError:
                 raise  # propagate along

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 logger = scenario_logger.getChild("runtime")
 STORED_STATE_REGEX = re.compile(
-    r"((?P<event_owner_path>.*)\/)?(?P<data_type_name>\D+)\[(?P<name>.*)\]",
+    r"((?P<owner_path>.*)\/)?(?P<data_type_name>\D+)\[(?P<name>.*)\]",
 )
 EVENT_REGEX = re.compile(_event_regex)
 

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -14,7 +14,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Sequence,
     Type,
     TypeVar,
     Union,
@@ -333,7 +332,6 @@ class Runtime:
         context: "Context",
         pre_event: Optional[Callable[["CharmType"], None]] = None,
         post_event: Optional[Callable[["CharmType"], None]] = None,
-        event_owner_path: Sequence[str] = None,
     ) -> "State":
         """Runs an event with this state as initial state on a charm.
 
@@ -388,7 +386,6 @@ class Runtime:
                     charm_spec=self._charm_spec.replace(
                         charm_type=self._wrap(charm_type),
                     ),
-                    event_owner_path=event_owner_path,
                 )
             except NoObserverError:
                 raise  # propagate along

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -795,7 +795,7 @@ class Status(_DCBase):
 class StoredState(_DCBase):
     # /-separated Object names. E.g. MyCharm/MyCharmLib.
     # if None, this StoredState instance is owned by the Framework.
-    owner_path: Optional[str]
+    event_owner_path: Optional[str]
 
     name: str = "_stored"
     content: Dict[str, Any] = dataclasses.field(default_factory=dict)
@@ -804,7 +804,7 @@ class StoredState(_DCBase):
 
     @property
     def handle_path(self):
-        return f"{self.owner_path or ''}/{self.data_type_name}[{self.name}]"
+        return f"{self.event_owner_path or ''}/{self.data_type_name}[{self.name}]"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -795,7 +795,7 @@ class Status(_DCBase):
 class StoredState(_DCBase):
     # /-separated Object names. E.g. MyCharm/MyCharmLib.
     # if None, this StoredState instance is owned by the Framework.
-    event_owner_path: Optional[str]
+    owner_path: Optional[str]
 
     name: str = "_stored"
     content: Dict[str, Any] = dataclasses.field(default_factory=dict)
@@ -804,7 +804,7 @@ class StoredState(_DCBase):
 
     @property
     def handle_path(self):
-        return f"{self.event_owner_path or ''}/{self.data_type_name}[{self.name}]"
+        return f"{self.owner_path or ''}/{self.data_type_name}[{self.name}]"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,16 @@
 import logging
-import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from scenario.context import Context
 
@@ -23,44 +32,13 @@ def trigger(
     charm_type: Type["CharmType"],
     pre_event: Optional[Callable[["CharmType"], None]] = None,
     post_event: Optional[Callable[["CharmType"], None]] = None,
-    # if not provided, will be autoloaded from charm_type.
     meta: Optional[Dict[str, Any]] = None,
     actions: Optional[Dict[str, Any]] = None,
     config: Optional[Dict[str, Any]] = None,
     charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
     juju_version: str = "3.0",
+    owner_path: Sequence[str] = None,
 ) -> "State":
-    """Trigger a charm execution with an Event and a State.
-
-    Calling this function will call ops' main() and set up the context according to the specified
-    State, then emit the event on the charm.
-
-    :arg event: the Event that the charm will respond to. Can be a string or an Event instance.
-    :arg state: the State instance to use as data source for the hook tool calls that the charm will
-        invoke when handling the Event.
-    :arg charm_type: the CharmBase subclass to call ``ops.main()`` on.
-    :arg pre_event: callback to be invoked right before emitting the event on the newly
-        instantiated charm. Will receive the charm instance as only positional argument.
-    :arg post_event: callback to be invoked right after emitting the event on the charm instance.
-        Will receive the charm instance as only positional argument.
-    :arg meta: charm metadata to use. Needs to be a valid metadata.yaml format (as a python dict).
-        If none is provided, we will search for a ``metadata.yaml`` file in the charm root.
-    :arg actions: charm actions to use. Needs to be a valid actions.yaml format (as a python dict).
-        If none is provided, we will search for a ``actions.yaml`` file in the charm root.
-    :arg config: charm config to use. Needs to be a valid config.yaml format (as a python dict).
-        If none is provided, we will search for a ``config.yaml`` file in the charm root.
-    :arg juju_version: Juju agent version to simulate.
-    :arg charm_root: virtual charm root the charm will be executed with.
-        If the charm, say, expects a `./src/foo/bar.yaml` file present relative to the
-        execution cwd, you need to use this. E.g.:
-
-        >>> virtual_root = tempfile.TemporaryDirectory()
-        >>> local_path = Path(local_path.name)
-        >>> (local_path / 'foo').mkdir()
-        >>> (local_path / 'foo' / 'bar.yaml').write_text('foo: bar')
-        >>> scenario, State(), (... charm_root=virtual_root)
-
-    """
     ctx = Context(
         charm_type=charm_type,
         meta=meta,
@@ -69,4 +47,10 @@ def trigger(
         charm_root=charm_root,
         juju_version=juju_version,
     )
-    return ctx.run(event, state=state, pre_event=pre_event, post_event=post_event)
+    return ctx.run(
+        event,
+        state=state,
+        pre_event=pre_event,
+        post_event=post_event,
+        owner_path=owner_path,
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -37,7 +37,7 @@ def trigger(
     config: Optional[Dict[str, Any]] = None,
     charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
     juju_version: str = "3.0",
-    owner_path: Sequence[str] = None,
+    event_owner_path: Sequence[str] = None,
 ) -> "State":
     ctx = Context(
         charm_type=charm_type,
@@ -52,5 +52,5 @@ def trigger(
         state=state,
         pre_event=pre_event,
         post_event=post_event,
-        owner_path=owner_path,
+        event_owner_path=event_owner_path,
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -37,7 +37,6 @@ def trigger(
     config: Optional[Dict[str, Any]] = None,
     charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
     juju_version: str = "3.0",
-    event_owner_path: Sequence[str] = None,
 ) -> "State":
     ctx = Context(
         charm_type=charm_type,
@@ -52,5 +51,4 @@ def trigger(
         state=state,
         pre_event=pre_event,
         post_event=post_event,
-        event_owner_path=event_owner_path,
     )

--- a/tests/test_e2e/test_custom_event_triggers.py
+++ b/tests/test_e2e/test_custom_event_triggers.py
@@ -142,11 +142,7 @@ def test_child_object_event():
             MyCharm._foo_called = True
 
     trigger(
-        State(),
-        "foo",
-        MyCharm,
-        meta=MyCharm.META,
-        owner_path=('obj', 'my_on')
+        State(), "foo", MyCharm, meta=MyCharm.META, event_owner_path=("obj", "my_on")
     )
 
     assert MyCharm._foo_called

--- a/tests/test_e2e/test_custom_event_triggers.py
+++ b/tests/test_e2e/test_custom_event_triggers.py
@@ -141,8 +141,6 @@ def test_child_object_event():
         def _on_foo(self, e):
             MyCharm._foo_called = True
 
-    trigger(
-        State(), "foo", MyCharm, meta=MyCharm.META, event_owner_path=("obj", "my_on")
-    )
+    trigger(State(), "obj.my_on.foo", MyCharm, meta=MyCharm.META)
 
     assert MyCharm._foo_called

--- a/tests/test_e2e/test_custom_event_triggers.py
+++ b/tests/test_e2e/test_custom_event_triggers.py
@@ -1,11 +1,11 @@
 import os
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 import pytest
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, Object
 
-from scenario import Event, State
+from scenario import State
 from scenario.ops_main_mock import NoObserverError
 from scenario.runtime import InconsistentScenarioError
 from tests.helpers import trigger
@@ -72,7 +72,7 @@ def test_funky_named_event_emitted():
     os.unsetenv("SCENARIO_SKIP_CONSISTENCY_CHECKS")
 
 
-def test_child_object_event_emitted():
+def test_child_object_event_emitted_no_path_raises():
     class FooEvent(EventBase):
         pass
 
@@ -80,7 +80,7 @@ def test_child_object_event_emitted():
         foo = EventSource(FooEvent)
 
     class MyObject(Object):
-        on = MyObjEvents()
+        my_on = MyObjEvents()
 
     class MyCharm(CharmBase):
         META = {"name": "mycharm"}
@@ -89,7 +89,7 @@ def test_child_object_event_emitted():
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.obj = MyObject(self, "child")
-            self.framework.observe(self.obj.on.foo, self._on_foo)
+            self.framework.observe(self.obj.my_on.foo, self._on_foo)
 
         def _on_foo(self, e):
             MyCharm._foo_called = True
@@ -116,4 +116,37 @@ def test_child_object_event_emitted():
             pre_event=pre_event,
             meta=MyCharm.META,
         )
+    assert MyCharm._foo_called
+
+
+def test_child_object_event():
+    class FooEvent(EventBase):
+        pass
+
+    class MyObjEvents(CharmEvents):
+        foo = EventSource(FooEvent)
+
+    class MyObject(Object):
+        my_on = MyObjEvents()
+
+    class MyCharm(CharmBase):
+        META = {"name": "mycharm"}
+        _foo_called = False
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.obj = MyObject(self, "child")
+            self.framework.observe(self.obj.my_on.foo, self._on_foo)
+
+        def _on_foo(self, e):
+            MyCharm._foo_called = True
+
+    trigger(
+        State(),
+        "foo",
+        MyCharm,
+        meta=MyCharm.META,
+        owner_path=('obj', 'my_on')
+    )
+
     assert MyCharm._foo_called

--- a/tests/test_e2e/test_juju_log.py
+++ b/tests/test_e2e/test_juju_log.py
@@ -4,7 +4,7 @@ import pytest
 from ops.charm import CharmBase
 
 from scenario import Context
-from scenario.state import State
+from scenario.state import JujuLogLine, State
 from tests.helpers import trigger
 
 logger = logging.getLogger("testing logger")
@@ -30,6 +30,8 @@ def mycharm():
 def test_juju_log(mycharm):
     ctx = Context(mycharm, meta=mycharm.META)
     ctx.run("start", State())
-    assert ctx.juju_log[16] == ("DEBUG", "Emitting Juju event start.")
+    assert ctx.juju_log[-2] == JujuLogLine(
+        level="DEBUG", message="Emitting Juju event start."
+    )
+    assert ctx.juju_log[-1] == JujuLogLine(level="WARNING", message="bar!")
     # prints are not juju-logged.
-    assert ctx.juju_log[17] == ("WARNING", "bar!")


### PR DESCRIPTION
Fixes #38 

Added custom event API:

```python
    class FooEvent(EventBase):
        pass

    class MyObjEvents(CharmEvents):
        foo = EventSource(FooEvent)

    class MyObject(Object):
        my_on = MyObjEvents()

    class MyCharm(CharmBase):
        def __init__(self, *args, **kwargs):
            super().__init__(*args, **kwargs)
            self.obj = MyObject(self, "child")
            self.framework.observe(self.obj.my_on.foo, self._on_foo)

    trigger(
        State(),
        "foo",
        MyCharm,
        owner_path=('obj', 'my_on')   # <<<--- this will tell Scenario where to find the event we're trying to emit
    )
```
