### PR TITLE
public next_relation_id and fix succession

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "4.0"
+version = "4.0.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -178,9 +178,6 @@ class Secret(_DCBase):
             object.__setattr__(self, "rotate", rotate)
 
 
-_RELATION_IDS_CTR = 0
-
-
 def normalize_name(s: str):
     """Event names need underscores instead of dashes."""
     return s.replace("-", "_")
@@ -207,16 +204,6 @@ class ParametrizedEvent:
         return self().deferred(handler=handler, event_id=event_id)
 
 
-def _generate_new_relation_id():
-    global _RELATION_IDS_CTR
-    _RELATION_IDS_CTR += 1
-    logger.info(
-        f"relation ID unset; automatically assigning {_RELATION_IDS_CTR}. "
-        f"If there are problems, pass one manually.",
-    )
-    return _RELATION_IDS_CTR
-
-
 @dataclasses.dataclass(frozen=True)
 class RelationBase(_DCBase):
     endpoint: str
@@ -224,8 +211,21 @@ class RelationBase(_DCBase):
     # we can derive this from the charm's metadata
     interface: str = None
 
+    NEXT_RELATION_ID = 1
+
+    @staticmethod
+    def _next_relation_id():
+        cur = RelationBase.NEXT_RELATION_ID
+        RelationBase.NEXT_RELATION_ID += 1
+        logger.info(
+            f"relation ID unset; automatically assigning "
+            f"{cur}. "
+            f"If there are problems, pass one manually.",
+        )
+        return cur
+
     # Every new Relation instance gets a new one, if there's trouble, override.
-    relation_id: int = dataclasses.field(default_factory=_generate_new_relation_id)
+    relation_id: int = dataclasses.field(default_factory=_next_relation_id)
 
     local_app_data: Dict[str, str] = dataclasses.field(default_factory=dict)
     local_unit_data: Dict[str, str] = dataclasses.field(default_factory=dict)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -211,12 +211,13 @@ class RelationBase(_DCBase):
     # we can derive this from the charm's metadata
     interface: str = None
 
-    NEXT_RELATION_ID = 1
+    _next_relation_id_counter = 1
 
     @staticmethod
-    def _next_relation_id():
-        cur = RelationBase.NEXT_RELATION_ID
-        RelationBase.NEXT_RELATION_ID += 1
+    def next_relation_id(update=True):
+        cur = RelationBase._next_relation_id_counter
+        if update:
+            RelationBase._next_relation_id_counter += 1
         logger.info(
             f"relation ID unset; automatically assigning "
             f"{cur}. "
@@ -225,7 +226,7 @@ class RelationBase(_DCBase):
         return cur
 
     # Every new Relation instance gets a new one, if there's trouble, override.
-    relation_id: int = dataclasses.field(default_factory=_next_relation_id)
+    relation_id: int = dataclasses.field(default_factory=next_relation_id)
 
     local_app_data: Dict[str, str] = dataclasses.field(default_factory=dict)
     local_unit_data: Dict[str, str] = dataclasses.field(default_factory=dict)

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -259,3 +259,41 @@ def test_action_params_type():
             MyCharm, meta={}, actions={"foo": {"params": {"bar": {"type": "boolean"}}}}
         ),
     )
+
+
+def test_duplicate_relation_ids():
+    assert_inconsistent(
+        State(
+            relations=[Relation("foo", relation_id=1), Relation("bar", relation_id=1)]
+        ),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={
+                "requires": {"foo": {"interface": "foo"}, "bar": {"interface": "bar"}}
+            },
+        ),
+    )
+
+
+def test_relation_without_endpoint():
+    assert_inconsistent(
+        State(
+            relations=[Relation("foo", relation_id=1), Relation("bar", relation_id=1)]
+        ),
+        Event("start"),
+        _CharmSpec(MyCharm, meta={}),
+    )
+
+    assert_consistent(
+        State(
+            relations=[Relation("foo", relation_id=1), Relation("bar", relation_id=1)]
+        ),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={
+                "requires": {"foo": {"interface": "foo"}, "bar": {"interface": "bar"}}
+            },
+        ),
+    )

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -306,7 +306,7 @@ def test_cannot_instantiate_relationbase():
 
 
 def test_relation_ids():
-    initial_id = RelationBase.NEXT_RELATION_ID
+    initial_id = RelationBase._next_relation_id_counter
     for i in range(10):
         rel = Relation("foo")
         assert rel.relation_id == initial_id + i

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -303,3 +303,10 @@ def test_trigger_sub_relation(mycharm):
 def test_cannot_instantiate_relationbase():
     with pytest.raises(RuntimeError):
         RelationBase("")
+
+
+def test_relation_ids():
+    initial_id = RelationBase.NEXT_RELATION_ID
+    for i in range(10):
+        rel = Relation("foo")
+        assert rel.relation_id == initial_id + i


### PR DESCRIPTION
- added a `RelationBase.NEXT_RELATION_ID` to retrieve the ID the next relation to be instantiated will get
- fixed a bug where the relation ID wouldn't increase