### PR TITLE
Bump PyYAML dependency and make it less strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = ["juju", "test"]
 
 dependencies = [
     "ops>=2.0",
-    "PyYAML==6.0",
+    "PyYAML>=6.0.1",
     "typer==0.7.0",
 ]
 readme = "README.md"


### PR DESCRIPTION
Bump PyYAML dependency to 6.0.1 to fix failing builds following release of Cython 3. Also make the requirement less strict to allow users to use newer releases.