### PR TITLE
Fix container root nonempty delete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.1.2"
+version = "5.1.3"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 import datetime
 import random
+import shutil
 from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Tuple, Union
@@ -414,7 +415,8 @@ class _MockPebbleClient(_TestingPebbleClient):
 
         # wipe just in case
         if container_root.exists():
-            container_root.rmdir()
+            # Path.rmdir will fail if root is nonempty
+            shutil.rmtree(container_root)
 
         # initialize simulated filesystem
         container_root.mkdir(parents=True)


### PR DESCRIPTION
minor bug where container root cleanup would fail because Path.rmdir raises if the dir is nonempty