### PR TITLE
vroot cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,10 +1032,10 @@ can't emit multiple events in a single charm execution.
 
 # The virtual charm root
 
-Before executing the charm, Scenario writes the metadata, config, and actions `yaml`s to a temporary directory. The
+Before executing the charm, Scenario copies the charm's `/src`, any libs, the metadata, config, and actions `yaml`s to a temporary directory. The
 charm will see that tempdir as its 'root'. This allows us to keep things simple when dealing with metadata that can be
 either inferred from the charm type being passed to `Context` or be passed to it as an argument, thereby overriding
-the inferred one. This also allows you to test with charms defined on the fly, as in:
+the inferred one. This also allows you to test charms defined on the fly, as in:
 
 ```python
 from ops.charm import CharmBase
@@ -1052,7 +1052,7 @@ ctx.run('start', State())
 ```
 
 A consequence of this fact is that you have no direct control over the tempdir that we are creating to put the metadata
-you are passing to trigger (because `ops` expects it to be a file...). That is, unless you pass your own:
+you are passing to `.run()` (because `ops` expects it to be a file...). That is, unless you pass your own:
 
 ```python
 from ops.charm import CharmBase
@@ -1073,8 +1073,11 @@ state = Context(
 ```
 
 Do this, and you will be able to set up said directory as you like before the charm is run, as well as verify its
-contents after the charm has run. Do keep in mind that the metadata files will be overwritten by Scenario, and therefore
-ignored.
+contents after the charm has run. Do keep in mind that any metadata files you create in it will be overwritten by Scenario, and therefore
+ignored, if you pass any metadata keys to `Context`. Omit `meta` in the call
+above, and Scenario will instead attempt to read `metadata.yaml` from the
+temporary directory.
+
 
 # Immutability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.2"
+version = "5.2.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -295,8 +295,9 @@ class Runtime:
         config_yaml = virtual_charm_root / "config.yaml"
         actions_yaml = virtual_charm_root / "actions.yaml"
 
-        metadata_files_present: Dict[Path, bool] = {
-            file: file.exists() for file in (metadata_yaml, config_yaml, actions_yaml)
+        metadata_files_present: Dict[Path, Union[str, False]] = {
+            file: file.read_text() if file.exists() else False
+            for file in (metadata_yaml, config_yaml, actions_yaml)
         }
 
         any_metadata_files_present_in_vroot = any(metadata_files_present.values())
@@ -328,9 +329,12 @@ class Runtime:
         yield virtual_charm_root
 
         if vroot_is_custom:
-            for file, present in metadata_files_present.items():
-                if not present:
+            for file, previous_content in metadata_files_present.items():
+                if not previous_content:  # False: file did not exist before
                     file.unlink()
+                else:
+                    file.write_text(previous_content)
+
         else:
             vroot.cleanup()
 

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -316,9 +316,10 @@ class Runtime:
         elif not spec.is_autoloaded and any_metadata_files_present_in_vroot:
             logger.warn(
                 f"Some metadata files found in custom user-provided vroot {vroot} "
-                f"while you have passed meta, config or actions to Context.run(). "
+                "while you have passed meta, config or actions to Context.run(). "
                 "Single source of truth are the arguments passed to Context.run(). "
-                "Vroot metadata files will be overwritten. "
+                "Vroot metadata files will be overwritten for the "
+                "duration of this test, and restored afterwards. "
                 "To avoid this, clean any metadata files from the vroot before calling run.",
             )
 

--- a/scenario/scripts/main.py
+++ b/scenario/scripts/main.py
@@ -1,12 +1,35 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+from importlib import metadata
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
 
 import typer
 
 from scenario.scripts import logger
 from scenario.scripts.snapshot import snapshot
 from scenario.scripts.state_apply import state_apply
+
+
+def _version():
+    """Print the scenario version and exit."""
+    try:
+        print(metadata.version("ops-scenario"))
+        return
+    except PackageNotFoundError:
+        pass
+
+    pyproject_toml = Path(__file__).parent.parent.parent / "pyproject.toml"
+
+    if not pyproject_toml.exists():
+        print("<weird>")
+        return
+
+    for line in pyproject_toml.read_text().split("\n"):
+        if line.startswith("version"):
+            print(line.split("=")[1].strip("\"' "))
+            return
 
 
 def main():
@@ -19,6 +42,7 @@ def main():
         rich_markup_mode="markdown",
     )
 
+    app.command(name="version")(_version)
     app.command(name="snapshot", no_args_is_help=True)(snapshot)
     app.command(name="state-apply", no_args_is_help=True)(state_apply)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -35,7 +35,7 @@ def trigger(
     meta: Optional[Dict[str, Any]] = None,
     actions: Optional[Dict[str, Any]] = None,
     config: Optional[Dict[str, Any]] = None,
-    charm_root: Optional[Dict["PathLike", "PathLike"]] = None,
+    charm_root: Optional["PathLike"] = None,
     juju_version: str = "3.0",
 ) -> "State":
     ctx = Context(

--- a/tests/test_e2e/test_vroot.py
+++ b/tests/test_e2e/test_vroot.py
@@ -52,19 +52,23 @@ def test_vroot(vroot):
 
 def test_vroot_cleanup_if_exists(vroot):
     meta_file = vroot / "metadata.yaml"
-    meta_file.write_text(yaml.safe_dump({"name": "karl"}))
+    raw_ori_meta = yaml.safe_dump({"name": "karl"})
+    meta_file.write_text(raw_ori_meta)
 
     with Context(MyCharm, meta=MyCharm.META, charm_root=vroot).manager(
         "start",
         State(),
     ) as mgr:
         assert meta_file.exists()
+        assert meta_file.read_text() == yaml.safe_dump({"name": "my-charm"})
         assert (
             mgr.charm.meta.name == "my-charm"
         )  # not karl! Context.meta takes precedence
         mgr.run()
         assert meta_file.exists()
 
+    # meta file was restored to its previous contents
+    assert meta_file.read_text() == raw_ori_meta
     assert meta_file.exists()
 
 

--- a/tests/test_e2e/test_vroot.py
+++ b/tests/test_e2e/test_vroot.py
@@ -23,9 +23,9 @@ class MyCharm(CharmBase):
 
 
 @pytest.fixture
-def vroot():
-    with tempfile.TemporaryDirectory() as myvroot:
-        t = Path(myvroot)
+def charm_virtual_root():
+    with tempfile.TemporaryDirectory() as mycharm_virtual_root:
+        t = Path(mycharm_virtual_root)
         src = t / "src"
         src.mkdir()
         foobar = src / "foo.bar"
@@ -39,23 +39,23 @@ def vroot():
         yield t
 
 
-def test_vroot(vroot):
+def test_charm_virtual_root(charm_virtual_root):
     out = trigger(
         State(),
         "start",
         charm_type=MyCharm,
         meta=MyCharm.META,
-        charm_root=vroot,
+        charm_root=charm_virtual_root,
     )
     assert out.unit_status == ("active", "hello world")
 
 
-def test_vroot_cleanup_if_exists(vroot):
-    meta_file = vroot / "metadata.yaml"
+def test_charm_virtual_root_cleanup_if_exists(charm_virtual_root):
+    meta_file = charm_virtual_root / "metadata.yaml"
     raw_ori_meta = yaml.safe_dump({"name": "karl"})
     meta_file.write_text(raw_ori_meta)
 
-    with Context(MyCharm, meta=MyCharm.META, charm_root=vroot).manager(
+    with Context(MyCharm, meta=MyCharm.META, charm_root=charm_virtual_root).manager(
         "start",
         State(),
     ) as mgr:
@@ -72,12 +72,12 @@ def test_vroot_cleanup_if_exists(vroot):
     assert meta_file.exists()
 
 
-def test_vroot_cleanup_if_not_exists(vroot):
-    meta_file = vroot / "metadata.yaml"
+def test_charm_virtual_root_cleanup_if_not_exists(charm_virtual_root):
+    meta_file = charm_virtual_root / "metadata.yaml"
 
     assert not meta_file.exists()
 
-    with Context(MyCharm, meta=MyCharm.META, charm_root=vroot).manager(
+    with Context(MyCharm, meta=MyCharm.META, charm_root=charm_virtual_root).manager(
         "start",
         State(),
     ) as mgr:


### PR DESCRIPTION
implemented vroot cleanup:

- scenario now allows metadata.yaml to be present in user-given vroot. if you pass `meta` to `scenario.Context`, metadata.yaml will be overwritten (and when Context is done, it will be restored to its previous state!). Same for actions and config.yaml.

- scenario now cleans up after itself: if it **created** any metadata files, it will delete them.