### PR TITLE
removed remote unit ids var from Relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,6 @@ To declare a peer relation, you should use `scenario.state.PeerRelation`. The co
 that peer relations do not have a "remote app" (it's this app, in fact). So unlike `Relation`, a `PeerRelation` does not
 have `remote_app_name` or `remote_app_data` arguments. Also, it talks in terms of `peers`:
 
-- `Relation.remote_unit_ids` maps to `PeerRelation.peers_ids`
 - `Relation.remote_units_data` maps to `PeerRelation.peers_data`
 
 ```python
@@ -488,7 +487,7 @@ remote unit that the event is about. The reason that this parameter is not suppl
 events, is that the relation already ties 'this app' to some 'remote app' (cfr. the `Relation.remote_app_name` attr),
 but not to a specific unit. What remote unit this event is about is not a `State` concern but an `Event` one.
 
-The `remote_unit_id` will default to the first ID found in the relation's `remote_unit_ids`, but if the test you are
+The `remote_unit_id` will default to the first ID found in the relation's `remote_units_data`, but if the test you are
 writing is close to that domain, you should probably override it and pass it manually.
 
 ```python

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -177,7 +177,9 @@ class _MockModelBackend(_ModelBackend):
         relation = self._get_relation_by_id(relation_id)
 
         if isinstance(relation, PeerRelation):
-            return tuple(f"{self.app_name}/{unit_id}" for unit_id in relation.peers_ids)
+            return tuple(
+                f"{self.app_name}/{unit_id}" for unit_id in relation.peers_data
+            )
         return tuple(
             f"{relation.remote_app_name}/{unit_id}"
             for unit_id in relation._remote_unit_ids

--- a/tests/test_e2e/test_state.py
+++ b/tests/test_e2e/test_state.py
@@ -147,7 +147,6 @@ def test_relation_get(mycharm):
                 interface="bar",
                 local_app_data={"a": "because"},
                 remote_app_name="remote",
-                remote_unit_ids=[0, 1, 2],
                 remote_app_data={"a": "b"},
                 local_unit_data={"c": "d"},
                 remote_units_data={0: {}, 1: {"e": "f"}, 2: {}},
@@ -198,9 +197,7 @@ def test_relation_set(mycharm):
         endpoint="foo",
         interface="bar",
         remote_app_name="remote",
-        remote_unit_ids=[1, 4],
-        local_app_data={},
-        local_unit_data={},
+        remote_units_data={1: {}, 4: {}},
     )
     state = State(
         leader=True,


### PR DESCRIPTION
removed redundant remote unit ids (alternative constructor for remote relation data), legacy