### PR TITLE
fix error when no remote unit data is passed to relation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.3"
+version = "5.3.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -231,12 +231,17 @@ class Runtime:
                         "but you probably should be parametrizing the event with `remote_unit_id` "
                         "to be explicit.",
                     )
-                else:
+                elif len(remote_unit_ids) > 1:
                     remote_unit_id = remote_unit_ids[0]
                     logger.warning(
                         "remote unit ID unset, and multiple remote unit IDs are present; "
                         "We will pick the first one and hope for the best. You should be passing "
                         "`remote_unit_id` to the Event constructor.",
+                    )
+                else:
+                    logger.warning(
+                        "remote unit ID unset; no remote unit data present. "
+                        "Is this a realistic scenario?",  # TODO: is it?
                     )
 
             if remote_unit_id is not None:

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -193,7 +193,7 @@ class Secret(_DCBase):
 
 
 def normalize_name(s: str):
-    """Event names need underscores instead of dashes."""
+    """Event names, in Scenario, uniformly use underscores instead of dashes."""
     return s.replace("-", "_")
 
 
@@ -927,9 +927,6 @@ class Event(_DCBase):
         return self.replace(relation_remote_unit_id=remote_unit_id)
 
     def __post_init__(self):
-        if "-" in self.path:
-            logger.warning(f"Only use underscores in event paths. {self.path!r}")
-
         path = normalize_name(self.path)
         # bypass frozen dataclass
         object.__setattr__(self, "path", path)


### PR DESCRIPTION
Allow
Relation(remote_units_data={}) :
a relation with no remote units.