### PR TITLE
SecretNotFoundError should be raised when a secret is not found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.5"
+version = "5.4.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.4"
+version = "5.5"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -12,6 +12,7 @@ from ops import pebble
 from ops.model import (
     ModelError,
     SecretInfo,
+    SecretNotFoundError,
     SecretRotate,
     _format_action_result_dict,
     _ModelBackend,
@@ -134,12 +135,12 @@ class _MockModelBackend(_ModelBackend):
             try:
                 return next(filter(lambda s: s.id == id, self._state.secrets))
             except StopIteration:
-                raise RuntimeError(f"not found: secret with id={id}.")
+                raise SecretNotFoundError()
         elif label:
             try:
                 return next(filter(lambda s: s.label == label, self._state.secrets))
             except StopIteration:
-                raise RuntimeError(f"not found: secret with label={label}.")
+                raise SecretNotFoundError()
         else:
             raise RuntimeError("need id or label.")
 

--- a/tests/test_e2e/test_secrets.py
+++ b/tests/test_e2e/test_secrets.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 from ops.charm import CharmBase
 from ops.framework import Framework
-from ops.model import SecretRotate
+from ops.model import SecretNotFoundError, SecretRotate
 
 from scenario.state import Relation, Secret, State
 from tests.helpers import trigger
@@ -25,9 +25,9 @@ def mycharm():
 
 def test_get_secret_no_secret(mycharm):
     def post_event(charm: CharmBase):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(SecretNotFoundError):
             assert charm.model.get_secret(id="foo")
-        with pytest.raises(RuntimeError):
+        with pytest.raises(SecretNotFoundError):
             assert charm.model.get_secret(label="foo")
 
     trigger(


### PR DESCRIPTION
Highly misleading, currently a different exception is raised by `scenario` than by `ops`, when a secret doesn't exist.

This is cirtical to testing our code, where we need to perform specific actions when a secret is not found, and continue running actions instead of breaking the execution flow