### PR TITLE
Error types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,11 +29,15 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
+  # Run the Ruff linter.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.2
     hooks:
-      - id: black
-        args: [--safe]
+      # Run the Ruff linter.
+      - id: ruff
+      # Run the Ruff formatter.
+      - id: ruff-format
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.13.0
     hooks:
@@ -48,19 +52,6 @@ repos:
     hooks:
       - id: tox-ini-fmt
         args: ["-p", "fix"]
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear==23.3.23
-          - flake8-comprehensions==3.12
-          - flake8-pytest-style==1.7.2
-          - flake8-spellcheck==0.28
-          - flake8-unused-arguments==0.0.13
-          - flake8-noqa==1.3.1
-          - pep8-naming==0.13.3
-          - flake8-pyproject==1.2.3
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.7.1"
     hooks:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ available. The charm has no config, no relations, no networks, no leadership, an
 With that, we can write the simplest possible scenario test:
 
 ```python
-from scenario import State, Context
+from scenario import State, Context, Event
 from ops.charm import CharmBase
 from ops.model import UnknownStatus
 
@@ -93,7 +93,7 @@ class MyCharm(CharmBase):
 
 def test_scenario_base():
     ctx = Context(MyCharm, meta={"name": "foo"})
-    out = ctx.run('start', State())
+    out = ctx.run(Event("start"), State())
     assert out.unit_status == UnknownStatus()
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.4.1"
+version = "5.5"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,38 @@ scenario = "scenario"
 include = '\.pyi?$'
 
 
-[tool.flake8]
-dictionaries = ["en_US","python","technical","django"]
-max-line-length = 100
-ignore = ["SC100", "SC200", "B008"]
+[tool.ruff]
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.11
+target-version = "py311"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
 
 [tool.isort]
 profile = "black"

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -64,6 +64,7 @@ def check_consistency(
     for check in (
         check_containers_consistency,
         check_config_consistency,
+        check_resource_consistency,
         check_event_consistency,
         check_secrets_consistency,
         check_storages_consistency,
@@ -90,6 +91,27 @@ def check_consistency(
             f"warning if you're sure. "
             f"The following warnings were found: {err_fmt}",
         )
+
+
+def check_resource_consistency(
+    *,
+    state: "State",
+    charm_spec: "_CharmSpec",
+    **_kwargs,  # noqa: U101
+) -> Results:
+    """Check the internal consistency of the resources from metadata and in State."""
+    errors = []
+    warnings = []
+
+    resources_from_meta = set(charm_spec.meta.get("resources", {}).keys())
+    resources_from_state = set(state.resources.keys())
+    if not resources_from_meta.issuperset(resources_from_state):
+        errors.append(
+            f"any and all resources passed to State.resources need to have been defined in "
+            f"metadata.yaml. Metadata resources: {resources_from_meta}; "
+            f"State.resources: {resources_from_state}.",
+        )
+    return Results(errors, warnings)
 
 
 def check_event_consistency(

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -103,8 +103,8 @@ def check_resource_consistency(
     errors = []
     warnings = []
 
-    resources_from_meta = set(charm_spec.meta.get("resources", {}).keys())
-    resources_from_state = set(state.resources.keys())
+    resources_from_meta = set(charm_spec.meta.get("resources", {}))
+    resources_from_state = set(state.resources)
     if not resources_from_meta.issuperset(resources_from_state):
         errors.append(
             f"any and all resources passed to State.resources need to have been defined in "

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -418,7 +418,7 @@ def check_relation_consistency(
 
     known_endpoints = [a[0] for a in all_relations_meta]
     for relation in state.relations:
-        if not (ep := relation.endpoint) in known_endpoints:
+        if (ep := relation.endpoint) not in known_endpoints:
             errors.append(f"relation endpoint {ep} is not declared in metadata.")
 
     seen_ids = set()

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -40,7 +40,7 @@ logger = scenario_logger.getChild("mocking")
 
 
 class ActionMissingFromContextError(Exception):
-    """Raised when the user attempts to action-related hook tools when not handling an action."""
+    """Raised when the user attempts to invoke action hook tools outside an action context."""
 
     # This is not an ops error: in ops, you'd have to go exceptionally out of your way to trigger
     # this flow.

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -163,12 +163,14 @@ class _MockModelBackend(_ModelBackend):
         if not isinstance(is_app, bool):
             raise TypeError("is_app parameter to relation_get must be a boolean")
 
-        if is_app:
-            version = JujuVersion(self._context.juju_version)
-            if not version.has_app_data():
-                raise RuntimeError(
-                    f"setting application data is not supported on Juju version {version}",
-                )
+        if not is_app:
+            return
+
+        version = JujuVersion(self._context.juju_version)
+        if not version.has_app_data():
+            raise RuntimeError(
+                f"setting application data is not supported on Juju version {version}",
+            )
 
     def relation_get(self, relation_id: int, member_name: str, is_app: bool):
         self._check_app_data_access(is_app)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -915,7 +915,7 @@ class State(_DCBase):
 
     def get_storages(self, name: str) -> Tuple["Storage", ...]:
         """Get all storages with this name."""
-        return tuple(filter(lambda s: s.name == name, self.storage))
+        return tuple(s for s in self.storage if s.name == name)
 
     # FIXME: not a great way to obtain a delta, but is "complete". todo figure out a better way.
     def jsonpatch_delta(self, other: "State"):

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -906,12 +906,7 @@ class State(_DCBase):
         #   foo_bar: ...
 
         normalized_endpoint = normalize_name(endpoint)
-        return tuple(
-            filter(
-                lambda c: normalize_name(c.endpoint) == normalized_endpoint,
-                self.relations,
-            ),
-        )
+        return tuple(r for r in self.relations if normalize_name(r.endpoint) == normalized_endpoint)
 
     def get_storages(self, name: str) -> Tuple["Storage", ...]:
         """Get all storages with this name."""

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -8,7 +8,7 @@ import inspect
 import re
 import typing
 from collections import namedtuple
-from itertools import chain
+from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, Union
 from uuid import uuid4
@@ -18,7 +18,6 @@ from ops import pebble
 from ops.charm import CharmEvents
 from ops.model import SecretRotate, StatusBase
 
-# from scenario.fs_mocks import _MockFileSystem, _MockStorageMount
 from scenario.logger import logger as scenario_logger
 
 JujuLogLine = namedtuple("JujuLogLine", ("level", "message"))
@@ -46,6 +45,26 @@ BREAK_ALL_RELATIONS = "BREAK_ALL_RELATIONS"
 DETACH_ALL_STORAGES = "DETACH_ALL_STORAGES"
 
 ACTION_EVENT_SUFFIX = "_action"
+# all builtin events except secret events. They're special because they carry secret metadata.
+BUILTIN_EVENTS = {
+    "start",
+    "stop",
+    "install",
+    "install",
+    "start",
+    "stop",
+    "remove",
+    "update_status",
+    "config_changed",
+    "upgrade_charm",
+    "pre_series_upgrade",
+    "post_series_upgrade",
+    "leader_elected",
+    "leader_settings_changed",
+    "collect_metrics",
+    "collect_app_status",
+    "collect_unit_status",
+}
 PEBBLE_READY_EVENT_SUFFIX = "_pebble_ready"
 RELATION_EVENTS_SUFFIX = {
     "_relation_changed",
@@ -880,7 +899,19 @@ class State(_DCBase):
 
     def get_relations(self, endpoint: str) -> Tuple["AnyRelation", ...]:
         """Get all relations on this endpoint from the current state."""
-        return tuple(filter(lambda c: c.endpoint == endpoint, self.relations))
+
+        # we rather normalize the endpoint than worry about cursed metadata situations such as:
+        # requires:
+        #   foo-bar: ...
+        #   foo_bar: ...
+
+        normalized_endpoint = normalize_name(endpoint)
+        return tuple(
+            filter(
+                lambda c: normalize_name(c.endpoint) == normalized_endpoint,
+                self.relations,
+            ),
+        )
 
     def get_storages(self, name: str) -> Tuple["Storage", ...]:
         """Get all storages with this name."""
@@ -967,6 +998,62 @@ class DeferredEvent(_DCBase):
         return self.handle_path.split("/")[-1].split("[")[0]
 
 
+class _EventType(str, Enum):
+    builtin = "builtin"
+    relation = "relation"
+    action = "action"
+    secret = "secret"
+    storage = "storage"
+    workload = "workload"
+    custom = "custom"
+
+
+class _EventPath(str):
+    def __new__(cls, string):
+        string = normalize_name(string)
+        instance = super().__new__(cls, string)
+
+        instance.name = name = string.split(".")[-1]
+        instance.owner_path = string.split(".")[:-1] or ["on"]
+
+        instance.suffix, instance.type = suffix, _ = _EventPath._get_suffix_and_type(
+            name,
+        )
+        if suffix:
+            instance.prefix, _ = string.rsplit(suffix)
+        else:
+            instance.prefix = string
+
+        instance.is_custom = suffix == ""
+        return instance
+
+    @staticmethod
+    def _get_suffix_and_type(s: str):
+        for suffix in RELATION_EVENTS_SUFFIX:
+            if s.endswith(suffix):
+                return suffix, _EventType.relation
+
+        if s.endswith(ACTION_EVENT_SUFFIX):
+            return ACTION_EVENT_SUFFIX, _EventType.action
+
+        if s in SECRET_EVENTS:
+            return s, _EventType.secret
+
+        # Whether the event name indicates that this is a storage event.
+        for suffix in STORAGE_EVENTS_SUFFIX:
+            if s.endswith(suffix):
+                return suffix, _EventType.storage
+
+        # Whether the event name indicates that this is a workload event.
+        if s.endswith(PEBBLE_READY_EVENT_SUFFIX):
+            return PEBBLE_READY_EVENT_SUFFIX, _EventType.workload
+
+        if s in BUILTIN_EVENTS:
+            return "", _EventType.builtin
+
+        return "", _EventType.custom
+
+
 @dataclasses.dataclass(frozen=True)
 class Event(_DCBase):
     path: str
@@ -1005,14 +1092,27 @@ class Event(_DCBase):
         return self.replace(relation_remote_unit_id=remote_unit_id)
 
     def __post_init__(self):
-        path = normalize_name(self.path)
+        path = _EventPath(self.path)
         # bypass frozen dataclass
         object.__setattr__(self, "path", path)
 
     @property
+    def _path(self) -> _EventPath:
+        # we converted it in __post_init__, but the type checker doesn't know about that
+        return typing.cast(_EventPath, self.path)
+
+    @property
     def name(self) -> str:
-        """Event name."""
-        return self.path.split(".")[-1]
+        """Full event name.
+
+        Consists of a 'prefix' and a 'suffix'. The suffix denotes the type of the event, the
+        prefix the name of the entity the event is about.
+
+        "foo-relation-changed":
+         - "foo"=prefix (name of a relation),
+         - "-relation-changed"=suffix (relation event)
+        """
+        return self._path.name
 
     @property
     def owner_path(self) -> List[str]:
@@ -1020,32 +1120,32 @@ class Event(_DCBase):
 
         If this event is defined on the toplevel charm class, it should be ['on'].
         """
-        return self.path.split(".")[:-1] or ["on"]
+        return self._path.owner_path
 
     @property
     def _is_relation_event(self) -> bool:
         """Whether the event name indicates that this is a relation event."""
-        return any(self.name.endswith(suffix) for suffix in RELATION_EVENTS_SUFFIX)
+        return self._path.type is _EventType.relation
 
     @property
     def _is_action_event(self) -> bool:
         """Whether the event name indicates that this is a relation event."""
-        return self.name.endswith(ACTION_EVENT_SUFFIX)
+        return self._path.type is _EventType.action
 
     @property
     def _is_secret_event(self) -> bool:
         """Whether the event name indicates that this is a secret event."""
-        return self.name in SECRET_EVENTS
+        return self._path.type is _EventType.secret
 
     @property
     def _is_storage_event(self) -> bool:
         """Whether the event name indicates that this is a storage event."""
-        return any(self.name.endswith(suffix) for suffix in STORAGE_EVENTS_SUFFIX)
+        return self._path.type is _EventType.storage
 
     @property
     def _is_workload_event(self) -> bool:
         """Whether the event name indicates that this is a workload event."""
-        return self.name.endswith("_pebble_ready")
+        return self._path.type is _EventType.workload
 
     # this method is private because _CharmSpec is not quite user-facing; also,
     # the user should know.
@@ -1065,31 +1165,8 @@ class Event(_DCBase):
         # `charm.lib.on.foo_relation_created` and therefore be  unique and the Framework is happy.
         # However, our Event data structure ATM has no knowledge of which Object/Handle it is
         # owned by. So the only thing we can do right now is: check whether the event name,
-        # assuming it is owned by the charm, is that of a builtin event or not.
-        builtins = []
-        for relation_name in chain(
-            charm_spec.meta.get("requires", ()),
-            charm_spec.meta.get("provides", ()),
-            charm_spec.meta.get("peers", ()),
-        ):
-            relation_name = relation_name.replace("-", "_")
-            for relation_evt_suffix in RELATION_EVENTS_SUFFIX:
-                builtins.append(relation_name + relation_evt_suffix)
-
-        for storage_name in charm_spec.meta.get("storages", ()):
-            storage_name = storage_name.replace("-", "_")
-            for storage_evt_suffix in STORAGE_EVENTS_SUFFIX:
-                builtins.append(storage_name + storage_evt_suffix)
-
-        for action_name in charm_spec.actions or ():
-            action_name = action_name.replace("-", "_")
-            builtins.append(action_name + ACTION_EVENT_SUFFIX)
-
-        for container_name in charm_spec.meta.get("containers", ()):
-            container_name = container_name.replace("-", "_")
-            builtins.append(container_name + PEBBLE_READY_EVENT_SUFFIX)
-
-        return event_name in builtins
+        # assuming it is owned by the charm, LOOKS LIKE that of a builtin event or not.
+        return self._path.type is not _EventType.custom
 
     def bind(self, state: State):
         """Attach to this event the state component it needs.
@@ -1101,7 +1178,7 @@ class Event(_DCBase):
         In case of ambiguity (e.g. multiple relations found on 'foo' for event
         'foo-relation-changed', we pop a warning and bind the first one. Use with care!
         """
-        entity_name = self.name.split("_")[0]
+        entity_name = self._path.prefix
 
         if self._is_workload_event and not self.container:
             try:

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -906,7 +906,11 @@ class State(_DCBase):
         #   foo_bar: ...
 
         normalized_endpoint = normalize_name(endpoint)
-        return tuple(r for r in self.relations if normalize_name(r.endpoint) == normalized_endpoint)
+        return tuple(
+            r
+            for r in self.relations
+            if normalize_name(r.endpoint) == normalized_endpoint
+        )
 
     def get_storages(self, name: str) -> Tuple["Storage", ...]:
         """Get all storages with this name."""

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -426,3 +426,44 @@ def test_storage_states():
             },
         ),
     )
+
+
+def test_resource_states():
+    # happy path
+    assert_consistent(
+        State(resources={"foo": "/foo/bar.yaml"}),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={"name": "yamlman", "resources": {"foo": {"type": "oci-image"}}},
+        ),
+    )
+
+    # no resources in state but some in meta: OK. Not realistic wrt juju but fine for testing
+    assert_consistent(
+        State(),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={"name": "yamlman", "resources": {"foo": {"type": "oci-image"}}},
+        ),
+    )
+
+    # resource not defined in meta
+    assert_inconsistent(
+        State(resources={"bar": "/foo/bar.yaml"}),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={"name": "yamlman", "resources": {"foo": {"type": "oci-image"}}},
+        ),
+    )
+
+    assert_inconsistent(
+        State(resources={"bar": "/foo/bar.yaml"}),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={"name": "yamlman"},
+        ),
+    )

--- a/tests/test_e2e/test_deferred.py
+++ b/tests/test_e2e/test_deferred.py
@@ -10,6 +10,7 @@ from ops.charm import (
 )
 from ops.framework import Framework
 
+from scenario import Context
 from scenario.state import Container, DeferredEvent, Relation, State, deferred
 from tests.helpers import trigger
 
@@ -34,7 +35,7 @@ def mycharm():
 
         def _on_event(self, event):
             self.captured.append(event)
-            if self.defer_next:
+            if self.defer_next > 0:
                 self.defer_next -= 1
                 return event.defer()
 
@@ -134,7 +135,9 @@ def test_deferred_relation_event_from_relation(mycharm):
     out = trigger(
         State(
             relations=[rel],
-            deferred=[rel.changed_event.deferred(handler=mycharm._on_event)],
+            deferred=[
+                rel.changed_event(remote_unit_id=1).deferred(handler=mycharm._on_event)
+            ],
         ),
         "start",
         mycharm,
@@ -144,6 +147,12 @@ def test_deferred_relation_event_from_relation(mycharm):
     # we deferred the first 2 events we saw: foo_relation_changed, start.
     assert len(out.deferred) == 2
     assert out.deferred[0].name == "foo_relation_changed"
+    assert out.deferred[0].snapshot_data == {
+        "relation_name": rel.endpoint,
+        "relation_id": rel.relation_id,
+        "app_name": "remote",
+        "unit_name": "remote/1",
+    }
     assert out.deferred[1].name == "start"
 
     # we saw start and foo_relation_changed.
@@ -178,3 +187,40 @@ def test_deferred_workload_event(mycharm):
     upstat, start = mycharm.captured
     assert isinstance(upstat, WorkloadEvent)
     assert isinstance(start, StartEvent)
+
+
+def test_defer_reemit_lifecycle_event(mycharm):
+    ctx = Context(mycharm, meta=mycharm.META)
+
+    mycharm.defer_next = 1
+    state_1 = ctx.run("update-status", State())
+
+    mycharm.defer_next = 0
+    state_2 = ctx.run("start", state_1)
+
+    assert [type(e).__name__ for e in ctx.emitted_events] == [
+        "UpdateStatusEvent",
+        "UpdateStatusEvent",
+        "StartEvent",
+    ]
+    assert len(state_1.deferred) == 1
+    assert not state_2.deferred
+
+
+def test_defer_reemit_relation_event(mycharm):
+    ctx = Context(mycharm, meta=mycharm.META)
+
+    rel = Relation("foo")
+    mycharm.defer_next = 1
+    state_1 = ctx.run(rel.created_event, State(relations=[rel]))
+
+    mycharm.defer_next = 0
+    state_2 = ctx.run("start", state_1)
+
+    assert [type(e).__name__ for e in ctx.emitted_events] == [
+        "RelationCreatedEvent",
+        "RelationCreatedEvent",
+        "StartEvent",
+    ]
+    assert len(state_1.deferred) == 1
+    assert not state_2.deferred

--- a/tests/test_e2e/test_event.py
+++ b/tests/test_e2e/test_event.py
@@ -1,7 +1,7 @@
 import pytest
 from ops import CharmBase
 
-from scenario.state import _EventType, Event, _CharmSpec
+from scenario.state import Event, _CharmSpec, _EventType
 
 
 @pytest.mark.parametrize(

--- a/tests/test_e2e/test_event.py
+++ b/tests/test_e2e/test_event.py
@@ -1,0 +1,50 @@
+import pytest
+from ops import CharmBase
+
+from scenario.state import _EventType, Event, _CharmSpec
+
+
+@pytest.mark.parametrize(
+    "evt, expected_type",
+    (
+        ("foo_relation_changed", _EventType.relation),
+        ("foo_relation_created", _EventType.relation),
+        ("foo_bar_baz_relation_created", _EventType.relation),
+        ("foo_storage_attached", _EventType.storage),
+        ("foo_storage_detaching", _EventType.storage),
+        ("foo_bar_baz_storage_detaching", _EventType.storage),
+        ("foo_pebble_ready", _EventType.workload),
+        ("foo_bar_baz_pebble_ready", _EventType.workload),
+        ("secret_removed", _EventType.secret),
+        ("foo", _EventType.custom),
+        ("kaboozle_bar_baz", _EventType.custom),
+    ),
+)
+def test_event_type(evt, expected_type):
+    event = Event(evt)
+    assert event._path.type is expected_type
+
+    assert event._is_relation_event is (expected_type is _EventType.relation)
+    assert event._is_storage_event is (expected_type is _EventType.storage)
+    assert event._is_workload_event is (expected_type is _EventType.workload)
+    assert event._is_secret_event is (expected_type is _EventType.secret)
+    assert event._is_action_event is (expected_type is _EventType.action)
+
+    class MyCharm(CharmBase):
+        pass
+
+    spec = _CharmSpec(
+        MyCharm,
+        meta={
+            "requires": {
+                "foo": {"interface": "bar"},
+                "foo_bar_baz": {"interface": "bar"},
+            },
+            "storage": {
+                "foo": {"type": "filesystem"},
+                "foo_bar_baz": {"type": "filesystem"},
+            },
+            "containers": {"foo": {}, "foo_bar_baz": {}},
+        },
+    )
+    assert event._is_builtin_event(spec) is (expected_type is not _EventType.custom)

--- a/tests/test_e2e/test_event_bind.py
+++ b/tests/test_e2e/test_event_bind.py
@@ -11,6 +11,13 @@ def test_bind_relation():
     assert event.bind(state).relation is foo_relation
 
 
+def test_bind_relation_complex_name():
+    event = Event("foo-bar-baz-relation-changed")
+    foo_relation = Relation("foo_bar_baz")
+    state = State(relations=[foo_relation])
+    assert event.bind(state).relation is foo_relation
+
+
 def test_bind_relation_notfound():
     event = Event("foo-relation-changed")
     state = State(relations=[])

--- a/tests/test_e2e/test_rubbish_events.py
+++ b/tests/test_e2e/test_rubbish_events.py
@@ -79,7 +79,7 @@ def test_custom_events_sub_raise(mycharm, evt_name):
         ("install", True),
         ("config-changed", True),
         ("foo-relation-changed", True),
-        ("bar-relation-changed", False),
+        ("bar-relation-changed", True),
     ),
 )
 def test_is_custom_event(mycharm, evt_name, expected):

--- a/tests/test_e2e/test_storage.py
+++ b/tests/test_e2e/test_storage.py
@@ -79,3 +79,13 @@ def test_storage_usage(storage_ctx):
     assert (
         storage.get_filesystem(storage_ctx) / "path.py"
     ).read_text() == "helloworlds"
+
+
+def test_storage_attached_event(storage_ctx):
+    storage = Storage("foo")
+    storage_ctx.run(storage.attached_event, State(storage=[storage]))
+
+
+def test_storage_detaching_event(storage_ctx):
+    storage = Storage("foo")
+    storage_ctx.run(storage.detaching_event, State(storage=[storage]))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -103,7 +103,8 @@ def test_env_cleanup_on_charm_error():
             state=State(),
             event=Event("box_relation_changed", relation=Relation("box")),
             context=Context(my_charm_type, meta=meta),
-        ) as charm:
+        ):
             assert os.getenv("JUJU_REMOTE_APP")
+            _ = 1 / 0  # raise some error
 
     assert os.getenv("JUJU_REMOTE_APP", None) is None

--- a/tox.ini
+++ b/tox.ini
@@ -54,8 +54,8 @@ commands =
 description = Format code.
 skip_install = true
 deps =
-    black
+    ruff
     isort
 commands =
-    black {[vars]tst_path} {[vars]src_path}
+    ruff format {[vars]tst_path} {[vars]src_path}
     isort --profile black {[vars]tst_path} {[vars]src_path}


### PR DESCRIPTION
This pr fixes a number of error types in `mocking.py` that differed from the ones raised by ops.

Additionally:
 - implements the last missing mock: resource-get!
 - fly-by-fixes another couple bugs I found
 - Fixes #73 
  
With this, Scenario proper is now feature-complete: all hook tools are mockable.