### PR TITLE
fix falsy config defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.6"
+version = "5.6.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -72,6 +72,9 @@ class _MockExecProcess:
         raise NotImplementedError()
 
 
+_NOT_GIVEN = object()  # non-None default value sentinel
+
+
 class _MockModelBackend(_ModelBackend):
     def __init__(
         self,
@@ -221,8 +224,10 @@ class _MockModelBackend(_ModelBackend):
 
         for key, value in charm_config["options"].items():
             # if it has a default, and it's not overwritten from State, use it:
-            if key not in state_config and (default_value := value.get("default")):
-                state_config[key] = default_value
+            if key not in state_config:
+                default_value = value.get("default", _NOT_GIVEN)
+                if default_value is not _NOT_GIVEN:  # accept False as default value
+                    state_config[key] = default_value
 
         return state_config  # full config
 

--- a/tests/test_e2e/test_config.py
+++ b/tests/test_e2e/test_config.py
@@ -41,6 +41,7 @@ def test_config_get_default_from_meta(mycharm):
     def check_cfg(charm: CharmBase):
         assert charm.config["foo"] == "bar"
         assert charm.config["baz"] == 2
+        assert charm.config["qux"] is False
 
     trigger(
         State(
@@ -53,6 +54,7 @@ def test_config_get_default_from_meta(mycharm):
             "options": {
                 "foo": {"type": "string"},
                 "baz": {"type": "integer", "default": 2},
+                "qux": {"type": "boolean", "default": False},
             },
         },
         post_event=check_cfg,


### PR DESCRIPTION
fixed a bug where config options with falsy default values would not be copied into user-provided config maps