### PR TITLE
extra bindings and network model rework [Do not merge]

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ remote_unit_2_is_joining_event = Event('foo-relation-changed', relation=relation
 
 ### Networks
 
-Each relation a charm has will 
+Each relation a charm has is associated with  
 A charm can define some `extra-bindings`
 
 

--- a/README.md
+++ b/README.md
@@ -527,6 +527,12 @@ remote_unit_2_is_joining_event = relation.joined_event(remote_unit_id=2)
 remote_unit_2_is_joining_event = Event('foo-relation-changed', relation=relation, relation_remote_unit_id=2)
 ```
 
+### Networks
+
+Each relation a charm has will 
+A charm can define some `extra-bindings`
+
+
 # Containers
 
 When testing a kubernetes charm, you can mock container interactions. When using the null state (`State()`), there will

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ remote_unit_2_is_joining_event = Event('foo-relation-changed', relation=relation
 
 ### Networks
 
-Each relation a charm has is associated with  
+Simplifying a bit the Juju "spaces" model, each integration endpoint a charm defines in its metadata is associated with a network. Regardless of whether there is a living relation over that endpoint, that is.  
 A charm can define some `extra-bindings`
 
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A scenario test consists of three broad steps:
     - optionally, you can use a context manager to get a hold of the charm instance and run assertions on internal APIs and the internal state of the charm and operator framework.
 
 The most basic scenario is one in which all is defaulted and barely any data is
-available. The charm has no config, no relations, no networks, no leadership, and its status is `unknown`.
+available. The charm has no config, no relations, no leadership, and its status is `unknown`.
 
 With that, we can write the simplest possible scenario test:
 
@@ -530,8 +530,22 @@ remote_unit_2_is_joining_event = Event('foo-relation-changed', relation=relation
 ### Networks
 
 Simplifying a bit the Juju "spaces" model, each integration endpoint a charm defines in its metadata is associated with a network. Regardless of whether there is a living relation over that endpoint, that is.  
-A charm can define some `extra-bindings`
 
+If your charm has a relation `"foo"` (defined in metadata.yaml), then the charm will be able at runtime to do `self.model.get_binding("foo").network`.
+The network you'll get by doing so is heavily defaulted (see `state.Network.default`) and good for most use-cases because the charm should typically not be concerned about what IP it gets. 
+
+On top of the relation-provided network bindings, a charm can also define some `extra-bindings` in its metadata.yaml and access them at runtime. Note that this is a deprecated feature that should not be relied upon. For completeness, we support it in Scenario.
+
+If you want to, you can override any of these relation or extra-binding associated networks with a custom one by passing it to `State.networks`.
+
+```python
+from scenario import State, Network
+state = State(networks={
+  'foo': Network.default(private_address='4.4.4.4')
+})
+```
+
+Where `foo` can either be the name of an `extra-bindings`-defined binding, or a relation endpoint.
 
 # Containers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.7.1"
+version = "6.0"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -5,7 +5,6 @@ import datetime
 import random
 import shutil
 from io import StringIO
-from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
@@ -145,20 +144,21 @@ class _MockModelBackend(_ModelBackend):
             # in scenario, you can create Secret(id="foo"),
             # but ops.Secret will prepend a "secret:" prefix to that ID.
             # we allow getting secret by either version.
-            try:
-                return next(
-                    filter(
-                        lambda s: canonicalize_id(s.id) == canonicalize_id(id),
-                        self._state.secrets,
-                    ),
-                )
-            except StopIteration:
-                raise SecretNotFoundError()
+            secrets = [
+                s
+                for s in self._state.secrets
+                if canonicalize_id(s.id) == canonicalize_id(id)
+            ]
+            if not secrets:
+                raise SecretNotFoundError(id)
+            return secrets[0]
+
         elif label:
-            try:
-                return next(filter(lambda s: s.label == label, self._state.secrets))
-            except StopIteration:
-                raise SecretNotFoundError()
+            secrets = [s for s in self._state.secrets if s.label == label]
+            if not secrets:
+                raise SecretNotFoundError(label)
+            return secrets[0]
+
         else:
             # if all goes well, this should never be reached. ops.model.Secret will check upon
             # instantiation that either an id or a label are set, and raise a TypeError if not.
@@ -239,67 +239,35 @@ class _MockModelBackend(_ModelBackend):
         return state_config  # full config
 
     def network_get(self, binding_name: str, relation_id: Optional[int] = None):
-        # is this an extra-binding-provided network?
-        if binding_name in self._charm_spec.meta.get("extra-bindings", ()):
+        # validation:
+        extra_bindings = self._charm_spec.meta.get("extra-bindings", ())
+        all_endpoints = self._charm_spec.get_all_relations()
+        non_sub_relations = {
+            name for name, meta in all_endpoints if meta.get("scope") != "container"
+        }
+
+        # - is binding_name a valid binding name?
+        if binding_name in extra_bindings:
+            logger.warning("extra-bindings is a deprecated feature")  # fyi
+
+            # - verify that if the binding is an extra binding, we're not ignoring a relation_id
             if relation_id is not None:
                 # this should not happen
-                raise RuntimeError(
+                logger.error(
                     "cannot pass relation_id to network_get if the binding name is "
                     "that of an extra-binding. Extra-bindings are not mapped to relation IDs.",
                 )
-            network = self._state.extra_bindings.get(binding_name, Network.default())
-            return network.hook_tool_output_fmt()
-
-        # is binding_name a valid relation binding name?
-        meta = self._charm_spec.meta
-        if binding_name not in set(
-            chain(
-                meta.get("peers", ()),
-                meta.get("requires", ()),
-                meta.get("provides", ()),
-            ),
-        ):
+        # - verify that the binding is a relation endpoint name, but not a subordinate one
+        elif binding_name not in non_sub_relations:
             logger.error(
                 f"cannot get network binding for {binding_name}: is not a valid relation "
                 f"endpoint name nor an extra-binding.",
             )
             raise RelationNotFoundError()
 
-        # Is this a network attached to a relation?
-        relations = self._state.get_relations(binding_name)
-        if relation_id:
-            try:
-                relation = next(
-                    filter(
-                        lambda r: r.relation_id == relation_id,
-                        relations,
-                    ),
-                )
-            except StopIteration as e:
-                logger.error(
-                    f"network-get error: "
-                    f"No relation found with endpoint={binding_name} and id={relation_id}.",
-                )
-                raise RelationNotFoundError() from e
-        else:
-            if not relations:
-                logger.warning(
-                    "Requesting the network for an endpoint with no active relations "
-                    "will return a defaulted network.",
-                )
-                return Network.default().hook_tool_output_fmt()
-
-            # TODO: is this accurate? Any relation in particular?
-            relation = relations[0]
-
-        from scenario.state import SubordinateRelation  # avoid cyclic imports
-
-        if isinstance(relation, SubordinateRelation):
-            raise RuntimeError(
-                "Subordinate relation has no associated network binding.",
-            )
-
-        return relation.network.hook_tool_output_fmt()
+        # We look in State.networks for an override. If not given, we return a default network.
+        network = self._state.networks.get(binding_name, Network.default())
+        return network.hook_tool_output_fmt()
 
     # setter methods: these can mutate the state.
     def application_version_set(self, version: str):

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -241,7 +241,7 @@ class BindAddress(_DCBase):
 
     def hook_tool_output_fmt(self):
         # dumps itself to dict in the same format the hook tool would
-        # todo support for legacy (deprecated `interfacename` and `macaddress` fields?
+        # todo support for legacy (deprecated) `interfacename` and `macaddress` fields?
         dct = {
             "interface-name": self.interface_name,
             "addresses": [dataclasses.asdict(addr) for addr in self.addresses],
@@ -268,13 +268,13 @@ class Network(_DCBase):
     @classmethod
     def default(
         cls,
-        private_address: str = "1.1.1.1",
+        private_address: str = "192.0.2.0",
         hostname: str = "",
         cidr: str = "",
         interface_name: str = "",
         mac_address: Optional[str] = None,
-        egress_subnets=("1.1.1.2/32",),
-        ingress_addresses=("1.1.1.2",),
+        egress_subnets=("192.0.2.0/24",),
+        ingress_addresses=("192.0.2.0",),
     ) -> "Network":
         """Helper to create a minimal, heavily defaulted Network."""
         return cls(

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -325,7 +325,8 @@ class RelationBase(_DCBase):
     #  relation have a different network?
     network: Network = dataclasses.field(default=None)
     """Network associated with this relation.
-    If left empty, a default network will be assigned automatically."""
+    If left empty, a default network will be assigned automatically
+    (except for subordinate relations)."""
 
     @property
     def _databags(self):
@@ -355,7 +356,7 @@ class RelationBase(_DCBase):
         for databag in self._databags:
             self._validate_databag(databag)
 
-        if self.network is None:
+        if type(self) is not SubordinateRelation and self.network is None:
             object.__setattr__(self, "network", Network.default())
 
     def _validate_databag(self, databag: dict):

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -15,6 +15,7 @@ from scenario.state import (
     Storage,
     SubordinateRelation,
     _CharmSpec,
+    Network,
 )
 
 
@@ -465,5 +466,42 @@ def test_resource_states():
         _CharmSpec(
             MyCharm,
             meta={"name": "yamlman"},
+        ),
+    )
+
+
+def test_networks_consistency():
+    assert_inconsistent(
+        State(extra_bindings={"foo": Network.default()}),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={"name": "wonky"},
+        ),
+    )
+
+    assert_inconsistent(
+        State(extra_bindings={"foo": Network.default()}),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={
+                "name": "pinky",
+                "extra-bindings": {"foo": {}},
+                "requires": {"foo": {"interface": "bar"}},
+            },
+        ),
+    )
+
+    assert_consistent(
+        State(extra_bindings={"foo": Network.default()}),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={
+                "name": "pinky",
+                "extra-bindings": {"foo": {}},
+                "requires": {"bar": {"interface": "bar"}},
+            },
         ),
     )

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -8,6 +8,7 @@ from scenario.state import (
     Action,
     Container,
     Event,
+    Network,
     PeerRelation,
     Relation,
     Secret,
@@ -15,7 +16,6 @@ from scenario.state import (
     Storage,
     SubordinateRelation,
     _CharmSpec,
-    Network,
 )
 
 

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -472,7 +472,7 @@ def test_resource_states():
 
 def test_networks_consistency():
     assert_inconsistent(
-        State(extra_bindings={"foo": Network.default()}),
+        State(networks={"foo": Network.default()}),
         Event("start"),
         _CharmSpec(
             MyCharm,
@@ -481,7 +481,7 @@ def test_networks_consistency():
     )
 
     assert_inconsistent(
-        State(extra_bindings={"foo": Network.default()}),
+        State(networks={"foo": Network.default()}),
         Event("start"),
         _CharmSpec(
             MyCharm,
@@ -494,7 +494,7 @@ def test_networks_consistency():
     )
 
     assert_consistent(
-        State(extra_bindings={"foo": Network.default()}),
+        State(networks={"foo": Network.default()}),
         Event("start"),
         _CharmSpec(
             MyCharm,

--- a/tests/test_e2e/test_network.py
+++ b/tests/test_e2e/test_network.py
@@ -52,7 +52,7 @@ def test_ip_get(mycharm):
                     relation_id=1,
                 ),
             ],
-            extra_bindings={"foo": Network.default(private_address="4.4.4.4")},
+            networks={"foo": Network.default(private_address="4.4.4.4")},
         ),
     ) as mgr:
         # we have a network for the relation
@@ -86,7 +86,7 @@ def test_no_sub_binding(mycharm):
             ]
         ),
     ) as mgr:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RelationNotFoundError):
             # sub relations have no network
             mgr.charm.model.get_binding("bar").network
 
@@ -114,7 +114,7 @@ def test_no_relation_error(mycharm):
                     relation_id=1,
                 ),
             ],
-            extra_bindings={"bar": Network.default()},
+            networks={"bar": Network.default()},
         ),
     ) as mgr:
         with pytest.raises(RelationNotFoundError):

--- a/tests/test_e2e/test_network.py
+++ b/tests/test_e2e/test_network.py
@@ -3,7 +3,8 @@ from ops import RelationNotFoundError
 from ops.charm import CharmBase
 from ops.framework import Framework
 
-from scenario.state import Event, Network, Relation, State, _CharmSpec
+from scenario import Context
+from scenario.state import Network, Relation, State
 from tests.helpers import trigger
 
 
@@ -28,13 +29,17 @@ def mycharm():
 
 
 def test_ip_get(mycharm):
-    mycharm._call = lambda *_: True
+    ctx = Context(
+        mycharm,
+        meta={
+            "name": "foo",
+            "requires": {"metrics-endpoint": {"interface": "foo"}},
+            "extra-bindings": {"foo": {}},
+        },
+    )
 
-    def fetch_unit_address(charm: CharmBase):
-        rel = charm.model.get_relation("metrics-endpoint")
-        assert str(charm.model.get_binding(rel).network.bind_address) == "1.1.1.1"
-
-    trigger(
+    with ctx.manager(
+        "update_status",
         State(
             relations=[
                 Relation(
@@ -44,16 +49,15 @@ def test_ip_get(mycharm):
                     relation_id=1,
                 ),
             ],
-            networks=[Network.default("metrics-endpoint")],
+            extra_bindings={"foo": Network.default(private_address="4.4.4.4")},
         ),
-        "update_status",
-        mycharm,
-        meta={
-            "name": "foo",
-            "requires": {"metrics-endpoint": {"interface": "foo"}},
-        },
-        post_event=fetch_unit_address,
-    )
+    ) as mgr:
+        # we have a network for the relation
+        rel = mgr.charm.model.get_relation("metrics-endpoint")
+        assert str(mgr.charm.model.get_binding(rel).network.bind_address) == "1.1.1.1"
+
+        # and an extra binding
+        assert str(mgr.charm.model.get_binding("foo").network.bind_address) == "4.4.4.4"
 
 
 def test_no_relation_error(mycharm):
@@ -74,7 +78,7 @@ def test_no_relation_error(mycharm):
                     relation_id=1,
                 ),
             ],
-            networks=[Network.default("metrics-endpoint")],
+            extra_bindings={"foo": Network.default()},
         ),
         "update_status",
         mycharm,

--- a/tests/test_e2e/test_network.py
+++ b/tests/test_e2e/test_network.py
@@ -57,12 +57,12 @@ def test_ip_get(mycharm):
     ) as mgr:
         # we have a network for the relation
         rel = mgr.charm.model.get_relation("metrics-endpoint")
-        assert str(mgr.charm.model.get_binding(rel).network.bind_address) == "1.1.1.1"
+        assert str(mgr.charm.model.get_binding(rel).network.bind_address) == "192.0.2.0"
 
         # we have a network for a binding without relations on it
         assert (
             str(mgr.charm.model.get_binding("deadnodead").network.bind_address)
-            == "1.1.1.1"
+            == "192.0.2.0"
         )
 
         # and an extra binding


### PR DESCRIPTION
Fixes #87 

This PR adds support for extra-bindings and reworks the network model to hopefully match Juju's more closely.

Issue: at the moment, if you want to add a Network, you always have to pass it in manually:

`State(relations=[rel1, rel2], networks=[net1, net2])`
 
While in fact the presence of an integration endpoint **implies** the presence of a network. So it feels like a charm should automatically have networks for each of its metadata-defined relation endpoints, regardless of whether the relations are 'alive' i.e. in State.

This PR changes the semantics and the type of `State.networks`: from an exhaustive list of the networks available to the charm being tested, to a binding name --> Network mapping: `State.networks: Dict[str, Network]`

The logic for `network_get(binding:str, relation_id:Optional[int])` is also updated:
- if binding is an extra-binding, return `State.networks[binding]` if found, else a default network.
- if binding is the name of a relation endpoint (except subordinates, which do not get a network):  return `State.networks[binding]` if found, else a default network.
- else, raise a fat exception
  
The idea is that now `State.networks` is an override mapping. The default network which you automatically get for each relation endpoint and extra-binding is not good enough, you can override it with a custom-defined one. For the most part, you will probably be fine using the default network, since in theory the charm should not have opinions about what IP it gets.

This is breaking, non-backwards-compatible, API change. Will release as v6.