### PR TITLE
loosened metadata checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "5.8"
+version = "5.8.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -942,6 +942,19 @@ class State(_DCBase):
         return sort_patch(patch)
 
 
+def _is_valid_charmcraft_25_metadata(meta: Dict[str, Any]):
+    # Check whether the metadata has the expected mandatory fields
+    if (config_type := meta.get("type")) != "charm":
+        logger.debug(
+            f"Not a charm: charmcraft yaml config ``.type`` is {config_type!r}.",
+        )
+        return False
+    if not all(field in meta for field in {"name", "summary", "description"}):
+        logger.debug("not a charm: charmcraft yaml misses some required")
+        return False
+    return True
+
+
 @dataclasses.dataclass(frozen=True)
 class _CharmSpec(_DCBase):
     """Charm spec."""
@@ -976,10 +989,7 @@ class _CharmSpec(_DCBase):
         """Load metadata from charm projects created with Charmcraft >= 2.5."""
         metadata_path = charm_root / "charmcraft.yaml"
         meta = yaml.safe_load(metadata_path.open()) if metadata_path.exists() else {}
-        if (config_type := meta.get("type")) != "charm":
-            logger.debug(
-                f"Not a charm: charmcraft yaml config ``.type`` is {config_type!r}.",
-            )
+        if not _is_valid_charmcraft_25_metadata(meta):
             meta = {}
         config = meta.pop("config", None)
         actions = meta.pop("actions", None)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -943,14 +943,15 @@ class State(_DCBase):
 
 
 def _is_valid_charmcraft_25_metadata(meta: Dict[str, Any]):
-    # Check whether the metadata has the expected mandatory fields
+    # Check whether this dict has the expected mandatory metadata fields according to the
+    # charmcraft >2.5 charmcraft.yaml schema
     if (config_type := meta.get("type")) != "charm":
         logger.debug(
             f"Not a charm: charmcraft yaml config ``.type`` is {config_type!r}.",
         )
         return False
     if not all(field in meta for field in {"name", "summary", "description"}):
-        logger.debug("not a charm: charmcraft yaml misses some required")
+        logger.debug("Not a charm: charmcraft yaml misses some required fields")
         return False
     return True
 


### PR DESCRIPTION
Fixes #92 

Issue:
- the presence of a charmcraft.yaml file confused the code used to determine what version of charmcraft was used to init the charm repo.


Solution:
- make the checks more accurate

