### PR TITLE
docs: fix event in README example for pebble-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,8 +601,9 @@ def test_pebble_push():
         )
         Context(
             MyCharm,
-            meta={"name": "foo", "containers": {"foo": {}}}).run(
-            "start",
+            meta={"name": "foo", "containers": {"foo": {}}}
+        ).run(
+            container.pebble_ready_event(),
             state_in,
         )
         assert local_file.read().decode() == "TEST"


### PR DESCRIPTION
I'm pretty sure this is a typo - the text immediately after this example talks about the `container.pebble_ready_event()` being sugar, but the code isn't using it (and also the test doesn't pass as-is, but does with this change).

Also a minor wrapping change, which I think makes it clearer what's happening (that the event is not an argument to `Context`).