### PR TITLE
Default data in databags

### DIFF
--- a/scenario/state.py
+++ b/scenario/state.py
@@ -360,7 +360,9 @@ class RelationBase(_DCBase):
     local_app_data: "RawDataBagContents" = dataclasses.field(default_factory=dict)
     """This application's databag for this relation."""
 
-    local_unit_data: "RawDataBagContents" = dataclasses.field(default_factory=dict)
+    local_unit_data: "RawDataBagContents" = dataclasses.field(
+        default_factory=lambda: DEFAULT_JUJU_DATABAG.copy(),
+    )
     """This unit's databag for this relation."""
 
     @property
@@ -490,7 +492,9 @@ class Relation(RelationBase):
 @dataclasses.dataclass(frozen=True)
 class SubordinateRelation(RelationBase):
     remote_app_data: "RawDataBagContents" = dataclasses.field(default_factory=dict)
-    remote_unit_data: "RawDataBagContents" = dataclasses.field(default_factory=dict)
+    remote_unit_data: "RawDataBagContents" = dataclasses.field(
+        default_factory=lambda: DEFAULT_JUJU_DATABAG.copy(),
+    )
 
     # app name and ID of the remote unit that *this unit* is attached to.
     remote_app_name: str = "remote"
@@ -526,7 +530,7 @@ class SubordinateRelation(RelationBase):
 @dataclasses.dataclass(frozen=True)
 class PeerRelation(RelationBase):
     peers_data: Dict["UnitID", "RawDataBagContents"] = dataclasses.field(
-        default_factory=lambda: {0: {}},
+        default_factory=lambda: {0: DEFAULT_JUJU_DATABAG.copy()},
     )
     # mapping from peer unit IDs to their databag contents.
     # Consistency checks will validate that *this unit*'s ID is not in here.

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -446,7 +446,7 @@ class RelationBase(_DCBase):
         )
 
 
-_DEFAULT_IP = "42.42.42.42"
+_DEFAULT_IP = " 192.0.2.0"
 DEFAULT_JUJU_DATABAG = {
     "egress-subnets": _DEFAULT_IP,
     "ingress-address": _DEFAULT_IP,

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -444,6 +444,14 @@ class RelationBase(_DCBase):
         )
 
 
+_DEFAULT_IP = "42.42.42.42"
+DEFAULT_JUJU_DATABAG = {
+    "egress-subnets": _DEFAULT_IP,
+    "ingress-address": _DEFAULT_IP,
+    "private-address": _DEFAULT_IP,
+}
+
+
 @dataclasses.dataclass(frozen=True)
 class Relation(RelationBase):
     remote_app_name: str = "remote"
@@ -453,7 +461,7 @@ class Relation(RelationBase):
 
     remote_app_data: "RawDataBagContents" = dataclasses.field(default_factory=dict)
     remote_units_data: Dict["UnitID", "RawDataBagContents"] = dataclasses.field(
-        default_factory=lambda: {0: {}},
+        default_factory=lambda: {0: DEFAULT_JUJU_DATABAG.copy()},  # dedup
     )
 
     @property

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -5,7 +5,6 @@ from ops.charm import CharmBase, CharmEvents, CollectStatusEvent, RelationDepart
 from ops.framework import EventBase, Framework
 
 from scenario.state import (
-    _DEFAULT_IP,
     DEFAULT_JUJU_DATABAG,
     PeerRelation,
     Relation,
@@ -231,42 +230,21 @@ def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name, caplog):
     )
 
 
-@pytest.mark.parametrize(
-    "evt_name",
-    ("changed", "broken", "departed", "joined", "created"),
-)
-def test_relation_events_remote_units_data_defaults(mycharm, evt_name, caplog):
-    relation = Relation(
-        endpoint="foo",
-        interface="foo",
-    )
+def test_relation_default_unit_data_regular():
+    relation = Relation("baz")
+    assert relation.local_unit_data == DEFAULT_JUJU_DATABAG
+    assert relation.remote_units_data == {0: DEFAULT_JUJU_DATABAG}
 
-    def callback(charm: CharmBase, event):
-        if isinstance(event, CollectStatusEvent):
-            return
 
-        assert event.app  # that's always present
-        remote_unit = event.relation.units.pop()
+def test_relation_default_unit_data_sub():
+    relation = SubordinateRelation("baz")
+    assert relation.local_unit_data == DEFAULT_JUJU_DATABAG
+    assert relation.remote_unit_data == DEFAULT_JUJU_DATABAG
 
-        assert event.relation.data[remote_unit] == DEFAULT_JUJU_DATABAG
 
-    mycharm._call = callback
-
-    trigger(
-        State(
-            relations=[
-                relation,
-            ],
-        ),
-        getattr(relation, f"{evt_name}_event"),
-        mycharm,
-        meta={
-            "name": "local",
-            "requires": {
-                "foo": {"interface": "foo"},
-            },
-        },
-    )
+def test_relation_default_unit_data_peer():
+    relation = PeerRelation("baz")
+    assert relation.local_unit_data == DEFAULT_JUJU_DATABAG
 
 
 @pytest.mark.parametrize(

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -5,6 +5,8 @@ from ops.charm import CharmBase, CharmEvents, CollectStatusEvent, RelationDepart
 from ops.framework import EventBase, Framework
 
 from scenario.state import (
+    _DEFAULT_IP,
+    DEFAULT_JUJU_DATABAG,
     PeerRelation,
     Relation,
     RelationBase,
@@ -226,6 +228,44 @@ def test_relation_events_no_attrs(mycharm, evt_name, remote_app_name, caplog):
 
     assert (
         "remote unit ID unset, and multiple remote unit IDs are present" in caplog.text
+    )
+
+
+@pytest.mark.parametrize(
+    "evt_name",
+    ("changed", "broken", "departed", "joined", "created"),
+)
+def test_relation_events_remote_units_data_defaults(mycharm, evt_name, caplog):
+    relation = Relation(
+        endpoint="foo",
+        interface="foo",
+    )
+
+    def callback(charm: CharmBase, event):
+        if isinstance(event, CollectStatusEvent):
+            return
+
+        assert event.app  # that's always present
+        remote_unit = event.relation.units.pop()
+
+        assert event.relation.data[remote_unit] == DEFAULT_JUJU_DATABAG
+
+    mycharm._call = callback
+
+    trigger(
+        State(
+            relations=[
+                relation,
+            ],
+        ),
+        getattr(relation, f"{evt_name}_event"),
+        mycharm,
+        meta={
+            "name": "local",
+            "requires": {
+                "foo": {"interface": "foo"},
+            },
+        },
     )
 
 

--- a/tests/test_e2e/test_state.py
+++ b/tests/test_e2e/test_state.py
@@ -6,7 +6,7 @@ from ops.charm import CharmBase, CharmEvents, CollectStatusEvent
 from ops.framework import EventBase, Framework
 from ops.model import ActiveStatus, UnknownStatus, WaitingStatus
 
-from scenario.state import Container, Relation, State, sort_patch
+from scenario.state import DEFAULT_JUJU_DATABAG, Container, Relation, State, sort_patch
 from tests.helpers import trigger
 
 CUSTOM_EVT_SUFFIXES = {
@@ -225,9 +225,9 @@ def test_relation_set(mycharm):
     assert asdict(out.relations[0]) == asdict(
         relation.replace(
             local_app_data={"a": "b"},
-            local_unit_data={"c": "d"},
+            local_unit_data={"c": "d", **DEFAULT_JUJU_DATABAG},
         )
     )
 
     assert out.relations[0].local_app_data == {"a": "b"}
-    assert out.relations[0].local_unit_data == {"c": "d"}
+    assert out.relations[0].local_unit_data == {"c": "d", **DEFAULT_JUJU_DATABAG}


### PR DESCRIPTION
This PR adds the default juju relation keys 
```
DEFAULT_JUJU_DATABAG = {
    "egress-subnets": _DEFAULT_IP,
    "ingress-address": _DEFAULT_IP,
    "private-address": _DEFAULT_IP,
}
```

To all unit databag default values in Relation, SubordinateRelation and PeerRelation.