### PR TITLE
Older ops compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "6.0.1"
+version = "6.0.2"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -126,6 +126,10 @@ def setup_framework(
             broken_relation_id=broken_relation_id,
         )
     else:
+        ops_logger.warning(
+            "It looks like this charm is using an older `ops` version. "
+            "You may experience weirdness. Please update ops.",
+        )
         model = ops.model.Model(meta, model_backend)
 
     charm_state_path = charm_dir / CHARM_STATE_FILE

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -115,9 +115,9 @@ def setup_framework(
         # If we are in a RelationBroken event, we want to know which relation is
         # broken within the model, not only in the event's `.relation` attribute.
         broken_relation_id = (
-            event.relation.relation_id
+            event.relation.relation_id  # type: ignore
             if event.name.endswith("_relation_broken")
-            else None  # type: ignore
+            else None
         )
 
         model = ops.model.Model(

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -111,7 +111,7 @@ def setup_framework(
     meta = CharmMeta.from_yaml(metadata, actions_metadata)
 
     # ops >= 2.10
-    if inspect.signature(ops.model.Model).parameters["broken_relation_id"]:
+    if inspect.signature(ops.model.Model).parameters.get("broken_relation_id"):
         # If we are in a RelationBroken event, we want to know which relation is
         # broken within the model, not only in the event's `.relation` attribute.
         broken_relation_id = (

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -110,12 +110,23 @@ def setup_framework(
 
     meta = CharmMeta.from_yaml(metadata, actions_metadata)
 
-    # If we are in a RelationBroken event, we want to know which relation is
-    # broken within the model, not only in the event's `.relation` attribute.
-    broken_relation_id = (
-        event.relation.relation_id if event.name.endswith("_relation_broken") else None  # type: ignore
-    )
-    model = ops.model.Model(meta, model_backend, broken_relation_id=broken_relation_id)
+    # ops >= 2.10
+    if inspect.signature(ops.model.Model).parameters["broken_relation_id"]:
+        # If we are in a RelationBroken event, we want to know which relation is
+        # broken within the model, not only in the event's `.relation` attribute.
+        broken_relation_id = (
+            event.relation.relation_id
+            if event.name.endswith("_relation_broken")
+            else None  # type: ignore
+        )
+
+        model = ops.model.Model(
+            meta,
+            model_backend,
+            broken_relation_id=broken_relation_id,
+        )
+    else:
+        model = ops.model.Model(meta, model_backend)
 
     charm_state_path = charm_dir / CHARM_STATE_FILE
 


### PR DESCRIPTION
charms that pin ops to <2.10 will have trouble with the breaking_relation_id args that scenario passes indiscriminately to ops.Model