### PR TITLE
feat: add support for ActionEvent.id

### DIFF
--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -191,12 +191,14 @@ class Runtime:
             # todo consider setting pwd, (python)path
         }
 
-        if event.name.endswith("_action"):
-            # todo: do we need some special metadata, or can we assume action names
-            #  are always dashes?
-            env["JUJU_ACTION_NAME"] = event.name[: -len("_action")].replace("_", "-")
-            assert event.action is not None
-            env["JUJU_ACTION_UUID"] = event.action.id
+        if event._is_action_event and (action := event.action):
+            env.update(
+                {
+                    # TODO: we should check we're doing the right thing here.
+                    "JUJU_ACTION_NAME": action.name.replace("_", "-"),
+                    "JUJU_ACTION_UUID": action.id,
+                },
+            )
 
         if event._is_relation_event and (relation := event.relation):
             if isinstance(relation, PeerRelation):

--- a/scenario/sequences.py
+++ b/scenario/sequences.py
@@ -58,9 +58,11 @@ def generate_startup_sequence(state_template: State):
         (
             (
                 Event(
-                    "leader_elected"
-                    if state_template.leader
-                    else "leader_settings_changed",
+                    (
+                        "leader_elected"
+                        if state_template.leader
+                        else "leader_settings_changed"
+                    ),
                 ),
                 state_template.copy(),
             ),

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1443,7 +1443,10 @@ class Action(_DCBase):
     params: Dict[str, "AnyJson"] = dataclasses.field(default_factory=dict)
 
     id: str = dataclasses.field(default_factory=next_action_id)
-    """Juju action ID. Every action invocation gets a new unique one."""
+    """Juju action ID.
+
+    Every action invocation is automatically assigned a new one. Override in
+    the rare cases where a specific ID is required."""
 
     @property
     def event(self) -> Event:

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1423,11 +1423,27 @@ class Event(_DCBase):
         )
 
 
+_next_action_id_counter = 1
+
+
+def next_action_id(update=True):
+    global _next_action_id_counter
+    cur = _next_action_id_counter
+    if update:
+        _next_action_id_counter += 1
+    # Juju currently uses numbers for the ID, but in the past used UUIDs, so
+    # we need these to be strings.
+    return str(cur)
+
+
 @dataclasses.dataclass(frozen=True)
 class Action(_DCBase):
     name: str
 
     params: Dict[str, "AnyJson"] = dataclasses.field(default_factory=dict)
+
+    id: str = dataclasses.field(default_factory=next_action_id)
+    """Juju action ID. Every action invocation gets a new unique one."""
 
     @property
     def event(self) -> Event:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,6 +4,7 @@ import pytest
 from ops import CharmBase
 
 from scenario import Action, Context, Event, State
+from scenario.state import next_action_id
 
 
 class MyCharm(CharmBase):
@@ -31,6 +32,7 @@ def test_run():
 def test_run_action():
     ctx = Context(MyCharm, meta={"name": "foo"})
     state = State()
+    expected_id = next_action_id(update=False)
 
     with patch.object(ctx, "_run_action") as p:
         ctx._output_state = (
@@ -46,6 +48,7 @@ def test_run_action():
     assert isinstance(a, Action)
     assert a.event.name == "do_foo_action"
     assert s is state
+    assert a.id == expected_id
 
 
 def test_clear():


### PR DESCRIPTION
Sets `JUJU_ACTION_UUID` when handling an action event, so that `ops` sets `ActionEvent.id` appropriately. The ID is loaded from `state.next_action_id` and set on the `state.Action` object, similarly to relations.

Also stops setting `JUJU_ACTION_NAME` outside of action events - mostly to simplify the code addition, but in my quick checks this is the case in Juju as well.

Fixes #101