### PR TITLE
fix: use default_factory to provide default UUID and name values for Model

### DIFF
--- a/scenario/state.py
+++ b/scenario/state.py
@@ -562,8 +562,8 @@ def _random_model_name():
 
 @dataclasses.dataclass(frozen=True)
 class Model(_DCBase):
-    name: str = _random_model_name()
-    uuid: str = str(uuid4())
+    name: str = dataclasses.field(default_factory=_random_model_name)
+    uuid: str = dataclasses.field(default_factory=lambda: str(uuid4()))
 
     # whatever juju models --format=json | jq '.models[<current-model-index>].type' gives back.
     # TODO: make this exhaustive.


### PR DESCRIPTION
Currently, Scenario defaults `Model.name` and `Model.uuid` to the same (random) value across all instances. This PR changes the class to use a `dataclasses.field` `default_factory` instead, so that each instance gets a unique (random) default.