### PR TITLE
fix: correct the consistency checker's config "type" validation

### DIFF
--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -6,7 +6,7 @@ import re
 from collections import Counter
 from collections.abc import Sequence
 from numbers import Number
-from typing import TYPE_CHECKING, Iterable, List, NamedTuple, Tuple
+from typing import TYPE_CHECKING, Iterable, List, NamedTuple, Tuple, Union
 
 from scenario.runtime import InconsistentScenarioError
 from scenario.runtime import logger as scenario_logger
@@ -327,10 +327,10 @@ def check_storages_consistency(
     return Results(errors, [])
 
 
-def _is_secret_identifier(value: str):
+def _is_secret_identifier(value: Union[str, int, float, bool]):
     """Return true iff the value is in the form `secret:{secret id}`."""
     # cf. https://github.com/juju/juju/blob/13eb9df3df16a84fd471af8a3c95ddbd04389b71/core/secrets/secret.go#L48
-    return re.match(r"secret:[0-9a-z]{20}$", secret_id)
+    return re.match(r"secret:[0-9a-z]{20}$", str(value))
 
 
 def check_config_consistency(

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -327,10 +327,10 @@ def check_storages_consistency(
     return Results(errors, [])
 
 
-def _is_secret_identifier(value: Union[str, int, float, bool]):
+def _is_secret_identifier(value: Union[str, int, float, bool]) -> bool:
     """Return true iff the value is in the form `secret:{secret id}`."""
     # cf. https://github.com/juju/juju/blob/13eb9df3df16a84fd471af8a3c95ddbd04389b71/core/secrets/secret.go#L48
-    return re.match(r"secret:[0-9a-z]{20}$", str(value))
+    return bool(re.match(r"secret:[0-9a-z]{20}$", str(value)))
 
 
 def check_config_consistency(
@@ -371,6 +371,7 @@ def check_config_consistency(
         if not expected_type_name:
             errors.append(f"config.yaml invalid; option {key!r} has no 'type'.")
             continue
+        validator = validators.get(expected_type_name)
 
         expected_type = converters.get(expected_type_name)
         if not expected_type:
@@ -384,7 +385,7 @@ def check_config_consistency(
                 f"but is of type {type(value)}.",
             )
 
-        elif not validators.get(expected_type_name, lambda _: True)(value):
+        elif validator and not validator(value):
             errors.append(
                 f"config invalid: option {key!r} value {value!r} is not valid.",
             )

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -358,7 +358,6 @@ def check_config_consistency(
             "int": int,
             "float": float,
             "boolean": bool,
-            # "attrs": NotImplemented,  # fixme: wot?
         }
         if juju_version >= (3, 4):
             converters["secret"] = str

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -384,9 +384,7 @@ def check_config_consistency(
                 f"but is of type {type(value)}.",
             )
 
-        elif expected_type_name in validators and not validators[expected_type_name](
-            value,
-        ):
+        elif not validators.get(expected_type_name, lambda _: True)(value):
             errors.append(
                 f"config invalid: option {key!r} value {value!r} is not valid.",
             )

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -327,7 +327,7 @@ def check_storages_consistency(
     return Results(errors, [])
 
 
-def _is_secret_identifier(value):
+def _is_secret_identifier(value: str):
     """Return true iff the value is in the form `secret:{secret id}`."""
     # cf. https://github.com/juju/juju/blob/13eb9df3df16a84fd471af8a3c95ddbd04389b71/core/secrets/secret.go#L48
     return re.match(r"secret:[0-9a-z]{20}$", secret_id)

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -329,11 +329,8 @@ def check_storages_consistency(
 
 def _is_secret_identifier(value):
     """Return true iff the value is in the form `secret:{secret id}`."""
-    if not value.startswith("secret:"):
-        return False
-    secret_id = value.split(":", 1)[1]
     # cf. https://github.com/juju/juju/blob/13eb9df3df16a84fd471af8a3c95ddbd04389b71/core/secrets/secret.go#L48
-    return re.match(r"^[0-9a-z]{20}$", secret_id)
+    return re.match(r"secret:[0-9a-z]{20}$", secret_id)
 
 
 def check_config_consistency(

--- a/tests/test_e2e/test_config.py
+++ b/tests/test_e2e/test_config.py
@@ -32,7 +32,7 @@ def test_config_get(mycharm):
         "update_status",
         mycharm,
         meta={"name": "foo"},
-        config={"options": {"foo": {"type": "string"}, "baz": {"type": "integer"}}},
+        config={"options": {"foo": {"type": "string"}, "baz": {"type": "int"}}},
         post_event=check_cfg,
     )
 


### PR DESCRIPTION
Some small corrections to the consistency checker's validation of the `type` field in config:

1. "integer" is not valid (at least in Juju 3.4.0), so remove it
2. "number" is not valid (at least in Juju 3.4.0), so remove it
3. "float" is missing, so add it
4. This is currently undocumented (that should be fixed soon) but "type: secret" is valid from Juju 3.4 onwards, so add it (conditionally on the Juju version)

Adjust tests to match.

See also canonical/operator#1166 for `type:secret` issue in `Harness`.