### PR TITLE
chore: drop tests for Python 2.6, 2.7, add 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,9 @@
 requires =
     tox>=4.2
 env_list =
+    py312
     py311
     py38
-    py37
-    py36
     unit
     lint
     lint-tests


### PR DESCRIPTION
[pyproject.toml](pyproject.toml) specifies that the minimum Python version is 3.8, so it doesn't seem to make sense to test against 3.6 or 3.7. Presumably, Scenario should support the same Python versions as ops, which is (I believe) a minimum version of the Python included with the oldest LTS still in standard support (so Python 3.8 in 22.04 until April 2025).

Add in tests against 3.12, since it seems reasonable for people to be using Python 3.12, and we'd want to know about breakage earlier rather than later anyway.