### PR TITLE
feat!: add basic StoredState consistency checks

### DIFF
--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -595,6 +595,6 @@ def check_storedstate_consistency(
             marshal.dumps(ss.content)
         except ValueError:
             errors.append(
-                f"{ss!r} must contain only simple types.",
+                f"The StoredState object {ss.owner_path}.{ss.name} should contain only simple types.",
             )
     return Results(errors, [])

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+import marshal
 import os
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Sequence
 from numbers import Number
 from typing import TYPE_CHECKING, Iterable, List, NamedTuple, Tuple
@@ -69,6 +70,7 @@ def check_consistency(
         check_storages_consistency,
         check_relation_consistency,
         check_network_consistency,
+        check_storedstate_consistency,
     ):
         results = check(
             state=state,
@@ -546,4 +548,35 @@ def check_containers_consistency(
     if dupes := [n for n in names if names[n] > 1]:
         errors.append(f"Duplicate container name(s): {dupes}.")
 
+    return Results(errors, [])
+
+
+def check_storedstate_consistency(
+    *,
+    state: "State",
+    **_kwargs,  # noqa: U101
+) -> Results:
+    """Check the internal consistency of `state.storedstate`."""
+    errors = []
+
+    # Attribute names must be unique on each object.
+    names = defaultdict(list)
+    for ss in state.stored_state:
+        names[ss.owner_path].append(ss.name)
+    for owner, owner_names in names.items():
+        if len(owner_names) != len(set(owner_names)):
+            errors.append(
+                f"{owner} has multiple StoredState objects with the same name.",
+            )
+
+    # The content must be marshallable.
+    for ss in state.stored_state:
+        # We don't need the marshalled state, just to know that it can be.
+        # This is the same "only simple types" check that ops does.
+        try:
+            marshal.dumps(ss.content)
+        except ValueError:
+            errors.append(
+                f"{ss!r} must contain only simple types.",
+            )
     return Results(errors, [])

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 logger = scenario_logger.getChild("runtime")
 STORED_STATE_REGEX = re.compile(
-    r"((?P<owner_path>.*)\/)?(?P<data_type_name>\D+)\[(?P<name>.*)\]",
+    r"((?P<owner_path>.*)\/)?(?P<_data_type_name>\D+)\[(?P<name>.*)\]",
 )
 EVENT_REGEX = re.compile(_event_regex)
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -773,13 +773,17 @@ class StoredState(_DCBase):
     owner_path: Optional[str]
 
     name: str = "_stored"
+    # Ideally, the type here would be only marshallable types, rather than Any.
+    # However, it's complex to describe those types, since it's a recursive
+    # definition - even in TypeShed the _Marshallable type includes containers
+    # like list[Any], which seems to defeat the point.
     content: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
-    data_type_name: str = "StoredStateData"
+    _data_type_name: str = "StoredStateData"
 
     @property
     def handle_path(self):
-        return f"{self.owner_path or ''}/{self.data_type_name}[{self.name}]"
+        return f"{self.owner_path or ''}/{self._data_type_name}[{self.name}]"
 
 
 _RawPortProtocolLiteral = Literal["tcp", "udp", "icmp"]

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -14,6 +14,7 @@ from scenario.state import (
     Secret,
     State,
     Storage,
+    StoredState,
     SubordinateRelation,
     _CharmSpec,
 )
@@ -502,6 +503,51 @@ def test_networks_consistency():
                 "name": "pinky",
                 "extra-bindings": {"foo": {}},
                 "requires": {"bar": {"interface": "bar"}},
+            },
+        ),
+    )
+
+
+def test_storedstate_consistency():
+    assert_consistent(
+        State(
+            stored_state=[
+                StoredState(None, content={"foo": "bar"}),
+                StoredState(None, "my_stored_state", content={"foo": 1}),
+                StoredState("MyCharmLib", content={"foo": None}),
+                StoredState("OtherCharmLib", content={"foo": (1, 2, 3)}),
+            ]
+        ),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={
+                "name": "foo",
+            },
+        ),
+    )
+    assert_inconsistent(
+        State(
+            stored_state=[
+                StoredState(None, content={"foo": "bar"}),
+                StoredState(None, "_stored", content={"foo": "bar"}),
+            ]
+        ),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={
+                "name": "foo",
+            },
+        ),
+    )
+    assert_inconsistent(
+        State(stored_state=[StoredState(None, content={"secret": Secret("foo", {})})]),
+        Event("start"),
+        _CharmSpec(
+            MyCharm,
+            meta={
+                "name": "foo",
             },
         ),
     )


### PR DESCRIPTION
* Check that there aren't StoredState objects in the state that apply to the same attribute on the same object
* Check that the StoredState object doesn't contain types that ops would not be able to store in Juju
* Make the `_data_type_name` attribute private