### PR TITLE
context as contextmanager

### DIFF
--- a/tests/test_e2e/test_secrets.py
+++ b/tests/test_e2e/test_secrets.py
@@ -38,9 +38,11 @@ def test_get_secret_no_secret(mycharm):
 
 
 def test_get_secret(mycharm):
-    with Context(mycharm, meta={"name": "local"}).manager(
+    with Context(
+        mycharm,
+        meta={"name": "local"},
+        event_or_action="update_status",
         state=State(secrets=[Secret(id="foo", contents={0: {"a": "b"}}, granted=True)]),
-        event="update_status",
     ) as mgr:
         assert mgr.charm.model.get_secret(id="foo").get_content()["a"] == "b"
 


### PR DESCRIPTION
sample implementation for the context as contextmanager idea:

before:
```python
ctx = scenario.Context(MyCharm)
with ctx.manager(my_event, my_state) as mgr:
    ...
```

after:
```python
ctx = scenario.Context(MyCharm, event=my_event, state=my_state)
with ctx() as mgr:
    out: State = mgr.run()
    
ctx.run(state=other_state)   # overrides my_state
ctx.run(event='update_status')   # overrides my_event
ctx.run_action(...)  # error

ctx = scenario.Context(MyCharm, action=my_action, state=my_state)
with ctx() as mgr:
    out: ActionOutput = mgr.run()
    
ctx.run(...)  # error
ctx.run_action(action=other_action)   # overrides my_action
ctx.run_action(state=other_state)   # overrides my_state
```

if you omit ((event and action) or state) from `__init__`, the context manager won't work and run/run_action will only work if you supply the missing argument

```python
ctx = scenario.Context(MyCharm, state=my_state)
with ctx() as mgr:  # error
    ...
    
ctx.run(state=other_state)  # error
ctx.run(event='update_status')  # runs with update-status, my_state
```

Pros:
- I really like how you can use `Context` itself as a contextmanager without additional methods.

Cons:
- Lots of complexity around argument management: we need to check a lot of possible combinations of user input paths, since the user can now supply the arguments we need in two separate places.
