### PR TITLE
Reset sys.excepthook.

### DIFF
--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 import inspect
 import os
+import sys
 from typing import TYPE_CHECKING, Any, Optional, Sequence, cast
 
 import ops.charm
@@ -96,6 +97,9 @@ def setup_framework(
     )
     debug = "JUJU_DEBUG" in os.environ
     setup_root_logging(model_backend, debug=debug)
+    # ops sets sys.excepthook to go to Juju's debug-log, but that's not useful
+    # in a testing context, so reset it.
+    sys.excepthook = sys.__excepthook__
     ops_logger.debug(
         "Operator Framework %s up and running.",
         ops.__version__,


### PR DESCRIPTION
This code currently has no output, but does fail:

<details>
<summary>example code</summary>

```python
import ops

import scenario

class MyCharm(ops.CharmBase):
    def __init__(self, framework):
        super().__init__(framework)
        framework.observe(self.on.config_changed, self._on_config_changed)

    def _on_config_changed(self, event):
        self.unit.get_container("example").replan()

ctx = scenario.Context(
    MyCharm,
    meta={"name": "my-charm", "containers": {"example": {"resource": "ubuntu-22.04"}}},
)
container = scenario.Container("example", can_connect=False)
state = scenario.State(containers=[container])
out = ctx.run("config-changed", state=state)
```

</details>

```
$ python /tmp/scenario-102.py ; echo $?
1
```

This PR resets the `sys.excepthook` change that ops does (to redirect output to Juju's debug-log), so that instead:

```
(venv) tameyer@tam-canoncial-1:~/code/ops-scenario$ python /tmp/scenario-102.py ; echo $?
Traceback (most recent call last):
[...]
  File "/home/tameyer/code/ops-scenario/scenario/mocking.py", line 711, in _check_connection
    raise pebble.ConnectionError(msg)
ops.pebble.ConnectionError: Cannot connect to Pebble; did you forget to set can_connect=True for container example?

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
[...]
  File "/home/tameyer/code/ops-scenario/scenario/runtime.py", line 442, in exec
    raise UncaughtCharmError(
scenario.runtime.UncaughtCharmError: Uncaught exception (<class 'ops.pebble.ConnectionError'>) in operator/charm code: <ops.pebble.ConnectionError ('Cannot connect to Pebble; did you forget to set can_connect=True for container example?',)>
1
```

I think this is more what people would expect (if you're running in pytest then you'd get this type of output anyway, but for cases when not doing that).

Fixes #102