### PR TITLE
ci: temporarily enable CI quality checks for the 7.0 branch

### DIFF
--- a/.github/workflows/quality_checks.yaml
+++ b/.github/workflows/quality_checks.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 7.0
 
 jobs:
   linting:


### PR DESCRIPTION
This should get reverted prior to (or just after) merging to main, but it would be handy to avoid the 7.0 branch getting into a bad state.