### PR TITLE
chore: update the add-trailing-comma hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.4.0
+    rev: v3.1.0
     hooks:
       - id: add-trailing-comma
         args: [--py36-plus]


### PR DESCRIPTION
Bumps the version of the add-trailing-comma hook tool to the latest, to avoid this:

```
tameyer@tam-canoncial-1:~/code/ops-scenario$ grep 'def storage_add' -A 5 scenario/mocking.py 
    def storage_add(self, name: str, count: int = 1):
        if not isinstance(count, int) or isinstance(count, bool):
            raise TypeError(
                f"storage count must be integer, got: {count} ({type(count)})",
            )

tameyer@tam-canoncial-1:~/code/ops-scenario$ pre-commit run --files scenario/mocking.py add-trailing-comma > /dev/null
tameyer@tam-canoncial-1:~/code/ops-scenario$ grep 'def storage_add' -A 5 scenario/mocking.py 
    def storage_add(self, name: str, count: int = 1):
        if not isinstance(count, int) or isinstance(count, bool):
            raise TypeError(
                f"storage count must be integer, got: {count} ({type(count)},
            )",
            )
```