### PR TITLE
feat: add support for Pebble check events

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,25 @@ notices = [
     scenario.Notice(key="example.com/c"),
 ]
 container = scenario.Container("my-container", notices=notices)
-ctx.run(container.get_notice("example.com/c").event, scenario.State(containers=[container]))
+state = scenario.State(containers={container})
+ctx.run(ctx.on.pebble_custom_notice(container=container, notice=notices[-1]), state)
+```
+
+### Pebble Checks
+
+A Pebble plan can contain checks, and when those checks exceed the configured
+failure threshold, or start succeeding again after, Juju will emit a
+pebble-check-failed or pebble-check-recovered event. In order to simulate these
+events, you need to add a `Check` to the container. Note that the status of the
+check doesn't have to match the event being generated: by the time that Juju
+sends a pebble-check-failed event the check might have started passing again.
+
+```python
+ctx = scenario.Context(MyCharm, meta={"name": "foo", "containers": {"my-container": {}}})
+check = scenario.Check("http-check", failures=7, status=ops.pebble.CheckStatus.DOWN)
+container = scenario.Container("my-container", checks={check})
+state = scenario.State(containers={container})
+ctx.run(ctx.on.pebble_check_failed(check=check, container=container), state=state)
 ```
 
 ## Storage

--- a/README.md
+++ b/README.md
@@ -700,16 +700,16 @@ ctx.run(ctx.on.pebble_custom_notice(container=container, notice=notices[-1]), st
 A Pebble plan can contain checks, and when those checks exceed the configured
 failure threshold, or start succeeding again after, Juju will emit a
 pebble-check-failed or pebble-check-recovered event. In order to simulate these
-events, you need to add a `Check` to the container. Note that the status of the
+events, you need to add a `CheckInfo` to the container. Note that the status of the
 check doesn't have to match the event being generated: by the time that Juju
 sends a pebble-check-failed event the check might have started passing again.
 
 ```python
 ctx = scenario.Context(MyCharm, meta={"name": "foo", "containers": {"my-container": {}}})
-check = scenario.Check("http-check", failures=7, status=ops.pebble.CheckStatus.DOWN)
-container = scenario.Container("my-container", checks={check})
+check_info = scenario.CheckInfo("http-check", failures=7, status=ops.pebble.CheckStatus.DOWN)
+container = scenario.Container("my-container", check_infos={check_info})
 state = scenario.State(containers={container})
-ctx.run(ctx.on.pebble_check_failed(check=check, container=container), state=state)
+ctx.run(ctx.on.pebble_check_failed(info=check_info, container=container), state=state)
 ```
 
 ## Storage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-#    "ops>=2.15",
-    "ops @ git+https://github.com/canonical/operator",
+    "ops>=2.15",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops>=2.15",
+#    "ops>=2.15",
+    "ops @ git+https://github.com/canonical/operator",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops>=2.12",
+#    "ops>=2.12",
+    "ops @ git+https://github.com/tonyandrewmeyer/operator@pebble-check-events",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-#    "ops>=2.12",
-    "ops @ git+https://github.com/tonyandrewmeyer/operator@pebble-check-events",
+    "ops>=2.15",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/scenario/__init__.py
+++ b/scenario/__init__.py
@@ -7,8 +7,8 @@ from scenario.state import (
     ActiveStatus,
     Address,
     BindAddress,
-    Check,
     BlockedStatus,
+    CheckInfo,
     CloudCredential,
     CloudSpec,
     Container,
@@ -40,7 +40,7 @@ from scenario.state import (
 __all__ = [
     "Action",
     "ActionOutput",
-    "Check",
+    "CheckInfo",
     "CloudCredential",
     "CloudSpec",
     "Context",

--- a/scenario/__init__.py
+++ b/scenario/__init__.py
@@ -6,6 +6,7 @@ from scenario.state import (
     Action,
     Address,
     BindAddress,
+    Check,
     CloudCredential,
     CloudSpec,
     Container,
@@ -33,6 +34,7 @@ from scenario.state import (
 __all__ = [
     "Action",
     "ActionOutput",
+    "Check",
     "CloudCredential",
     "CloudSpec",
     "Context",

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -560,7 +560,9 @@ def check_containers_consistency(
     meta_containers = list(map(normalize_name, meta.get("containers", {})))
     state_containers = [normalize_name(c.name) for c in state.containers]
     all_notices = {notice.id for c in state.containers for notice in c.notices}
-    all_checks = {check.name for c in state.containers for check in c.check_infos}
+    all_checks = {
+        (c.name, check.name) for c in state.containers for check in c.check_infos
+    }
     errors = []
 
     # it's fine if you have containers in meta that are not in state.containers (yet), but it's
@@ -585,10 +587,13 @@ def check_containers_consistency(
                 f"the event being processed concerns notice {event.notice!r}, but that "
                 "notice is not in any of the containers present in the state.",
             )
-        if event.check_info and event.check_info.name not in all_checks:
+        if (
+            event.check_info
+            and (evt_container_name, event.check_info.name) not in all_checks
+        ):
             errors.append(
                 f"the event being processed concerns check {event.check_info.name}, but that "
-                "check is not in any of the containers present in the state.",
+                "check is not the {evt_container_name} container.",
             )
 
     # - a container in state.containers is not in meta.containers

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -560,7 +560,7 @@ def check_containers_consistency(
     meta_containers = list(map(normalize_name, meta.get("containers", {})))
     state_containers = [normalize_name(c.name) for c in state.containers]
     all_notices = {notice.id for c in state.containers for notice in c.notices}
-    all_checks = {check.name for c in state.containers for check in c.checks}
+    all_checks = {check.name for c in state.containers for check in c.check_infos}
     errors = []
 
     # it's fine if you have containers in meta that are not in state.containers (yet), but it's

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -560,6 +560,7 @@ def check_containers_consistency(
     meta_containers = list(map(normalize_name, meta.get("containers", {})))
     state_containers = [normalize_name(c.name) for c in state.containers]
     all_notices = {notice.id for c in state.containers for notice in c.notices}
+    all_checks = {check.name for c in state.containers for check in c.checks}
     errors = []
 
     # it's fine if you have containers in meta that are not in state.containers (yet), but it's
@@ -583,6 +584,11 @@ def check_containers_consistency(
             errors.append(
                 f"the event being processed concerns notice {event.notice!r}, but that "
                 "notice is not in any of the containers present in the state.",
+            )
+        if event.check and event.check.name not in all_checks:
+            errors.append(
+                f"the event being processed concerns check {event.check!r}, but that "
+                "check is not in any of the containers present in the state.",
             )
 
     # - a container in state.containers is not in meta.containers

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -585,9 +585,9 @@ def check_containers_consistency(
                 f"the event being processed concerns notice {event.notice!r}, but that "
                 "notice is not in any of the containers present in the state.",
             )
-        if event.check and event.check.name not in all_checks:
+        if event.check_info and event.check_info.name not in all_checks:
             errors.append(
-                f"the event being processed concerns check {event.check!r}, but that "
+                f"the event being processed concerns check {event.check_info.name}, but that "
                 "check is not in any of the containers present in the state.",
             )
 

--- a/scenario/context.py
+++ b/scenario/context.py
@@ -13,8 +13,10 @@ from scenario.logger import logger as scenario_logger
 from scenario.runtime import Runtime
 from scenario.state import (
     Action,
+    Check,
     Container,
     MetadataNotFoundError,
+    Notice,
     Secret,
     Storage,
     _CharmSpec,
@@ -311,6 +313,30 @@ class _CharmEvents:
     @staticmethod
     def pebble_ready(container: Container):
         return _Event(f"{container.name}_pebble_ready", container=container)
+
+    @staticmethod
+    def pebble_custom_notice(container: Container, notice: Notice):
+        return _Event(
+            f"{container.name}_pebble_custom_notice",
+            container=container,
+            notice=notice,
+        )
+
+    @staticmethod
+    def pebble_check_failed(container: Container, check: Check):
+        return _Event(
+            f"{container.name}_pebble_check_failed",
+            container=container,
+            check=check,
+        )
+
+    @staticmethod
+    def pebble_check_recovered(container: Container, check: Check):
+        return _Event(
+            f"{container.name}_pebble_check_recovered",
+            container=container,
+            check=check,
+        )
 
 
 class Context:

--- a/scenario/context.py
+++ b/scenario/context.py
@@ -13,7 +13,7 @@ from scenario.logger import logger as scenario_logger
 from scenario.runtime import Runtime
 from scenario.state import (
     Action,
-    Check,
+    CheckInfo,
     Container,
     MetadataNotFoundError,
     Notice,
@@ -323,7 +323,7 @@ class _CharmEvents:
         )
 
     @staticmethod
-    def pebble_check_failed(container: Container, check: Check):
+    def pebble_check_failed(container: Container, check: CheckInfo):
         return _Event(
             f"{container.name}_pebble_check_failed",
             container=container,
@@ -331,7 +331,7 @@ class _CharmEvents:
         )
 
     @staticmethod
-    def pebble_check_recovered(container: Container, check: Check):
+    def pebble_check_recovered(container: Container, check: CheckInfo):
         return _Event(
             f"{container.name}_pebble_check_recovered",
             container=container,

--- a/scenario/context.py
+++ b/scenario/context.py
@@ -323,19 +323,19 @@ class _CharmEvents:
         )
 
     @staticmethod
-    def pebble_check_failed(container: Container, check: CheckInfo):
+    def pebble_check_failed(container: Container, info: CheckInfo):
         return _Event(
             f"{container.name}_pebble_check_failed",
             container=container,
-            check=check,
+            check_info=info,
         )
 
     @staticmethod
-    def pebble_check_recovered(container: Container, check: CheckInfo):
+    def pebble_check_recovered(container: Container, info: CheckInfo):
         return _Event(
             f"{container.name}_pebble_check_recovered",
             container=container,
-            check=check,
+            check_info=info,
         )
 
 

--- a/scenario/context.py
+++ b/scenario/context.py
@@ -338,6 +338,7 @@ class _CharmEvents:
             check_info=info,
         )
 
+    @staticmethod
     def action(
         name: str,
         params: Optional[Dict[str, "AnyJson"]] = None,
@@ -349,6 +350,7 @@ class _CharmEvents:
         if id:
             kwargs["id"] = id
         return _Event(f"{name}_action", action=_Action(name, **kwargs))
+
 
 class Context:
     """Represents a simulated charm's execution context.

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -689,8 +689,9 @@ class _MockPebbleClient(_TestingPebbleClient):
 
         self._root = container_root
 
-        # load any existing notices from the state
+        # load any existing notices and check information from the state
         self._notices: Dict[Tuple[str, str], pebble.Notice] = {}
+        self._check_infos: Dict[str, pebble.CheckInfo] = {}
         for container in state.containers:
             for notice in container.notices:
                 if hasattr(notice.type, "value"):
@@ -698,6 +699,8 @@ class _MockPebbleClient(_TestingPebbleClient):
                 else:
                     notice_type = str(notice.type)
                 self._notices[notice_type, notice.key] = notice._to_ops()
+            for check in container.checks:
+                self._check_infos[check.name] = check._to_ops()
 
     def get_plan(self) -> pebble.Plan:
         return self._container.plan

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -701,7 +701,7 @@ class _MockPebbleClient(_TestingPebbleClient):
                 else:
                     notice_type = str(notice.type)
                 self._notices[notice_type, notice.key] = notice._to_ops()
-            for check in container.checks:
+            for check in container.check_infos:
                 self._check_infos[check.name] = check._to_ops()
 
     def get_plan(self) -> pebble.Plan:

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -271,6 +271,9 @@ class Runtime:
                 },
             )
 
+        if check := event.check:
+            env["JUJU_PEBBLE_CHECK_NAME"] = check.name
+
         if storage := event.storage:
             env.update({"JUJU_STORAGE_ID": f"{storage.name}/{storage.index}"})
 

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -271,8 +271,8 @@ class Runtime:
                 },
             )
 
-        if check := event.check:
-            env["JUJU_PEBBLE_CHECK_NAME"] = check.name
+        if check_info := event.check_info:
+            env["JUJU_PEBBLE_CHECK_NAME"] = check_info.name
 
         if storage := event.storage:
             env.update({"JUJU_STORAGE_ID": f"{storage.name}/{storage.index}"})

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1668,8 +1668,8 @@ class _Event:
     notice: Optional[Notice] = None
     """If this is a Pebble notice event, the notice it refers to."""
 
-    check: Optional[CheckInfo] = None
-    """If this is a Pebble check event, the check it refers to."""
+    check_info: Optional[CheckInfo] = None
+    """If this is a Pebble check event, the check info it provides."""
 
     action: Optional["Action"] = None
     """If this is an action event, the :class:`Action` it refers to."""
@@ -1788,8 +1788,8 @@ class _Event:
                         "notice_type": notice_type,
                     },
                 )
-            elif self.check:
-                snapshot_data["check_name"] = self.check.name
+            elif self.check_info:
+                snapshot_data["check_name"] = self.check_info.name
 
         elif self._is_relation_event:
             # this is a RelationEvent.
@@ -1866,7 +1866,7 @@ def deferred(
     relation: Optional["Relation"] = None,
     container: Optional["Container"] = None,
     notice: Optional["Notice"] = None,
-    check: Optional["CheckInfo"] = None,
+    check_info: Optional["CheckInfo"] = None,
 ):
     """Construct a DeferredEvent from an Event or an event name."""
     if isinstance(event, str):
@@ -1875,6 +1875,6 @@ def deferred(
             relation=relation,
             container=container,
             notice=notice,
-            check=check,
+            check_info=check_info,
         )
     return event.deferred(handler=handler, event_id=event_id)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -869,7 +869,7 @@ class Container(_max_posargs(1)):
 
     notices: List[Notice] = dataclasses.field(default_factory=list)
 
-    checks: FrozenSet[CheckInfo] = frozenset()
+    check_infos: FrozenSet[CheckInfo] = frozenset()
 
     def __hash__(self) -> int:
         return hash(self.name)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -769,7 +769,7 @@ class Notice(_max_posargs(1)):
 
 
 @dataclasses.dataclass(frozen=True)
-class Check(_max_posargs(1)):
+class CheckInfo(_max_posargs(1)):
     name: str
     """Name of the check."""
 
@@ -869,7 +869,7 @@ class Container(_max_posargs(1)):
 
     notices: List[Notice] = dataclasses.field(default_factory=list)
 
-    checks: FrozenSet[Check] = frozenset()
+    checks: FrozenSet[CheckInfo] = frozenset()
 
     def __hash__(self) -> int:
         return hash(self.name)
@@ -1668,7 +1668,7 @@ class _Event:
     notice: Optional[Notice] = None
     """If this is a Pebble notice event, the notice it refers to."""
 
-    check: Optional[Check] = None
+    check: Optional[CheckInfo] = None
     """If this is a Pebble check event, the check it refers to."""
 
     action: Optional["Action"] = None
@@ -1866,7 +1866,7 @@ def deferred(
     relation: Optional["Relation"] = None,
     container: Optional["Container"] = None,
     notice: Optional["Notice"] = None,
-    check: Optional["Check"] = None,
+    check: Optional["CheckInfo"] = None,
 ):
     """Construct a DeferredEvent from an Event or an event name."""
     if isinstance(event, str):

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -87,7 +87,7 @@ def test_workload_event_without_container():
     )
     check = CheckInfo("http-check")
     assert_consistent(
-        State(containers={Container("foo", checks={check})}),
+        State(containers={Container("foo", check_infos={check})}),
         _Event("foo-pebble-check-failed", container=Container("foo"), check_info=check),
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
@@ -97,7 +97,7 @@ def test_workload_event_without_container():
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
     assert_consistent(
-        State(containers={Container("foo", checks={check})}),
+        State(containers={Container("foo", check_infos={check})}),
         _Event(
             "foo-pebble-check-recovered", container=Container("foo"), check_info=check
         ),

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -8,7 +8,7 @@ from scenario.runtime import InconsistentScenarioError
 from scenario.state import (
     RELATION_EVENTS_SUFFIX,
     Action,
-    Check,
+    CheckInfo,
     CloudCredential,
     CloudSpec,
     Container,
@@ -85,7 +85,7 @@ def test_workload_event_without_container():
         _Event("foo-pebble-custom-notice", container=Container("foo"), notice=notice),
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
-    check = Check("http-check")
+    check = CheckInfo("http-check")
     assert_consistent(
         State(containers={Container("foo", checks={check})}),
         _Event("foo-pebble-check-failed", container=Container("foo"), check=check),

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -110,6 +110,21 @@ def test_workload_event_without_container():
         ),
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
+    # Ensure the check is in the correct container.
+    assert_inconsistent(
+        State(containers={Container("foo", check_infos={check}), Container("bar")}),
+        _Event(
+            "foo-pebble-check-recovered", container=Container("bar"), check_info=check
+        ),
+        _CharmSpec(MyCharm, {"containers": {"foo": {}, "bar": {}}}),
+    )
+    assert_inconsistent(
+        State(containers={Container("foo", check_infos={check}), Container("bar")}),
+        _Event(
+            "bar-pebble-check-recovered", container=Container("bar"), check_info=check
+        ),
+        _CharmSpec(MyCharm, {"containers": {"foo": {}, "bar": {}}}),
+    )
 
 
 def test_container_meta_mismatch():

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -8,6 +8,7 @@ from scenario.runtime import InconsistentScenarioError
 from scenario.state import (
     RELATION_EVENTS_SUFFIX,
     Action,
+    Check,
     CloudCredential,
     CloudSpec,
     Container,
@@ -82,6 +83,27 @@ def test_workload_event_without_container():
     assert_inconsistent(
         State(containers={Container("foo")}),
         _Event("foo-pebble-custom-notice", container=Container("foo"), notice=notice),
+        _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
+    )
+    check = Check("http-check")
+    assert_consistent(
+        State(containers={Container("foo", checks={check})}),
+        _Event("foo-pebble-check-failed", container=Container("foo"), check=check),
+        _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
+    )
+    assert_inconsistent(
+        State(containers={Container("foo")}),
+        _Event("foo-pebble-check-failed", container=Container("foo"), check=check),
+        _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
+    )
+    assert_consistent(
+        State(containers={Container("foo", checks={check})}),
+        _Event("foo-pebble-check-recovered", container=Container("foo"), check=check),
+        _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
+    )
+    assert_inconsistent(
+        State(containers={Container("foo")}),
+        _Event("foo-pebble-check-recovered", container=Container("foo"), check=check),
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
 

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -88,22 +88,26 @@ def test_workload_event_without_container():
     check = CheckInfo("http-check")
     assert_consistent(
         State(containers={Container("foo", checks={check})}),
-        _Event("foo-pebble-check-failed", container=Container("foo"), check=check),
+        _Event("foo-pebble-check-failed", container=Container("foo"), check_info=check),
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
     assert_inconsistent(
         State(containers={Container("foo")}),
-        _Event("foo-pebble-check-failed", container=Container("foo"), check=check),
+        _Event("foo-pebble-check-failed", container=Container("foo"), check_info=check),
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
     assert_consistent(
         State(containers={Container("foo", checks={check})}),
-        _Event("foo-pebble-check-recovered", container=Container("foo"), check=check),
+        _Event(
+            "foo-pebble-check-recovered", container=Container("foo"), check_info=check
+        ),
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
     assert_inconsistent(
         State(containers={Container("foo")}),
-        _Event("foo-pebble-check-recovered", container=Container("foo"), check=check),
+        _Event(
+            "foo-pebble-check-recovered", container=Container("foo"), check_info=check
+        ),
         _CharmSpec(MyCharm, {"containers": {"foo": {}}}),
     )
 

--- a/tests/test_e2e/test_deferred.py
+++ b/tests/test_e2e/test_deferred.py
@@ -102,7 +102,9 @@ def test_deferred_workload_evt(mycharm):
 def test_deferred_notice_evt(mycharm):
     notice = Notice(key="example.com/bar")
     ctr = Container("foo", notices=[notice])
-    evt1 = ctr.get_notice("example.com/bar").event.deferred(handler=mycharm._on_event)
+    evt1 = _Event("foo_pebble_custom_notice", notice=notice, container=ctr).deferred(
+        handler=mycharm._on_event
+    )
     evt2 = deferred(
         event="foo_pebble_custom_notice",
         handler=mycharm._on_event,

--- a/tests/test_e2e/test_pebble.py
+++ b/tests/test_e2e/test_pebble.py
@@ -455,7 +455,7 @@ def test_pebble_check_failed():
 
     ctx = Context(MyCharm, meta={"name": "foo", "containers": {"foo": {}}})
     check = CheckInfo("http-check", failures=7, status=pebble.CheckStatus.DOWN)
-    container = Container("foo", checks={check})
+    container = Container("foo", check_infos={check})
     state = State(containers={container})
     ctx.run(ctx.on.pebble_check_failed(container, check), state=state)
     assert len(infos) == 1
@@ -479,7 +479,7 @@ def test_pebble_check_recovered():
 
     ctx = Context(MyCharm, meta={"name": "foo", "containers": {"foo": {}}})
     check = CheckInfo("http-check")
-    container = Container("foo", checks={check})
+    container = Container("foo", check_infos={check})
     state = State(containers={container})
     ctx.run(ctx.on.pebble_check_recovered(container, check), state=state)
     assert len(infos) == 1

--- a/tests/test_e2e/test_pebble.py
+++ b/tests/test_e2e/test_pebble.py
@@ -10,7 +10,7 @@ from ops.framework import Framework
 from ops.pebble import ExecError, ServiceStartup, ServiceStatus
 
 from scenario import Context
-from scenario.state import Check, Container, ExecOutput, Mount, Notice, State
+from scenario.state import CheckInfo, Container, ExecOutput, Mount, Notice, State
 from tests.helpers import jsonpatch_delta, trigger
 
 
@@ -455,7 +455,7 @@ def test_pebble_check_failed():
             assert info.failures == 7
 
     ctx = Context(MyCharm, meta={"name": "foo", "containers": {"foo": {}}})
-    check = Check("http-check", failures=7, status=pebble.CheckStatus.DOWN)
+    check = CheckInfo("http-check", failures=7, status=pebble.CheckStatus.DOWN)
     container = Container("foo", checks={check})
     state = State(containers={container})
     ctx.run(ctx.on.pebble_check_failed(check=check, container=container), state=state)
@@ -476,7 +476,7 @@ def test_pebble_check_recovered():
             assert info.failures == 0
 
     ctx = Context(MyCharm, meta={"name": "foo", "containers": {"foo": {}}})
-    check = Check("http-check")
+    check = CheckInfo("http-check")
     container = Container("foo", checks={check})
     state = State(containers={container})
     ctx.run(

--- a/tests/test_e2e/test_pebble.py
+++ b/tests/test_e2e/test_pebble.py
@@ -457,7 +457,7 @@ def test_pebble_check_failed():
     check = CheckInfo("http-check", failures=7, status=pebble.CheckStatus.DOWN)
     container = Container("foo", checks={check})
     state = State(containers={container})
-    ctx.run(ctx.on.pebble_check_failed(check=check, container=container), state=state)
+    ctx.run(ctx.on.pebble_check_failed(container, check), state=state)
     assert len(infos) == 1
     assert infos[0].name == "http-check"
     assert infos[0].status == pebble.CheckStatus.DOWN
@@ -481,9 +481,7 @@ def test_pebble_check_recovered():
     check = CheckInfo("http-check")
     container = Container("foo", checks={check})
     state = State(containers={container})
-    ctx.run(
-        ctx.on.pebble_check_recovered(check=check, container=container), state=state
-    )
+    ctx.run(ctx.on.pebble_check_recovered(container, check), state=state)
     assert len(infos) == 1
     assert infos[0].name == "http-check"
     assert infos[0].status == pebble.CheckStatus.UP

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,6 @@ allowlist_externals =
     cp
 deps =
     -e .
-    ops
     pytest
     pytest-markdown-docs
 commands =


### PR DESCRIPTION
Adds support for the {container-name}-pebble-check-failed and {container-name}-pebble-check-recovered events that will be available in Juju 3.6.

Example usage:

```python
ctx = Context(MyCharm)
check_info = CheckInfo("http-check", failures=7, status=ops.pebble.CheckStatus.DOWN)
container = Container("my-container", check_infos={check_info})
state = State(containers={container})

ctx.run(ctx.on.pebble_check_failed(container=container, info=check_info), state)
```

Also updates the support for Pebble custom notice events to align with the 7.x approach (event from ctx.on, notices are a frozenset).

Updated usage:

```python
ctx = Context(MyCharm)
notices = [
    Notice(key="example.com/a", occurrences=10),
    Notice(key="example.com/b", last_data={"bar": "baz"}),
    Notice(key="example.com/c"),
]
container = Container("my-container", notices=notices)
state = State(containers={container})

ctx.run(ctx.on.pebble_custom_notice(container=container, notice=notices[-1]), state)
```