### PR TITLE
fix: fix secret-remove and secret-expired events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "6.1.2"
+version = "6.1.3"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/runtime.py
+++ b/scenario/runtime.py
@@ -272,6 +272,8 @@ class Runtime:
                     "JUJU_SECRET_LABEL": secret.label or "",
                 },
             )
+            if event.name in ("secret_remove", "secret_expired"):
+                env["JUJU_SECRET_REVISION"] = str(secret.revision)
 
         return env
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -106,7 +106,7 @@ STORAGE_EVENTS_SUFFIX = {
 
 SECRET_EVENTS = {
     "secret_changed",
-    "secret_removed",
+    "secret_remove",
     "secret_rotate",
     "secret_expired",
 }
@@ -292,18 +292,18 @@ class Secret(_DCBase):
         """Sugar to generate a secret-expired event."""
         if not self.owner:
             raise ValueError(
-                "This unit will never receive secret-expire for a secret it does not own.",
+                "This unit will never receive secret-expired for a secret it does not own.",
             )
-        return Event("secret_expire", secret=self)
+        return Event("secret_expired", secret=self)
 
     @property
     def remove_event(self):
         """Sugar to generate a secret-remove event."""
         if not self.owner:
             raise ValueError(
-                "This unit will never receive secret-removed for a secret it does not own.",
+                "This unit will never receive secret-remove for a secret it does not own.",
             )
-        return Event("secret_removed", secret=self)
+        return Event("secret_remove", secret=self)
 
     def _set_revision(self, revision: int):
         """Set a new tracked revision."""

--- a/tests/test_e2e/test_event.py
+++ b/tests/test_e2e/test_event.py
@@ -19,7 +19,7 @@ from scenario.state import Event, State, _CharmSpec, _EventType
         ("foo_bar_baz_pebble_ready", _EventType.workload),
         ("foo_pebble_custom_notice", _EventType.workload),
         ("foo_bar_baz_pebble_custom_notice", _EventType.workload),
-        ("secret_removed", _EventType.secret),
+        ("secret_remove", _EventType.secret),
         ("pre_commit", _EventType.framework),
         ("commit", _EventType.framework),
         ("collect_unit_status", _EventType.framework),


### PR DESCRIPTION
Fixes the `secret-remove` event name and sets the `JUJU_SECRET_REVISION` environment variable for rotate and expired events. Adds a basic test that each type of secret event can be emitted.

There's a more significant revamp of secret events coming in 7.x but this fixes the core issues for 6.x.

Fixes #157.