### PR TITLE
feat!: make action events more like other events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 venv/
 build/
-docs/build/
+docs/_build/
 *.charm
 .tox/
 .coverage

--- a/README.md
+++ b/README.md
@@ -957,7 +957,7 @@ def test_backup_action():
 
     # If you didn't declare do_backup in the charm's metadata, 
     # the `ConsistencyChecker` will slap you on the wrist and refuse to proceed.
-    out: scenario.ActionOutput = ctx.run_action("do_backup_action", scenario.State())
+    out: scenario.ActionOutput = ctx.run_action(ctx.on.action("do_backup"), scenario.State())
 
     # You can assert action results, logs, failure using the ActionOutput interface:
     assert out.logs == ['baz', 'qux']
@@ -973,17 +973,18 @@ def test_backup_action():
 
 ## Parametrized Actions
 
-If the action takes parameters, you'll need to instantiate an `Action`.
+If the action takes parameters, you can pass those in the call.
 
 ```python
 def test_backup_action():
-    # Define an action:
-    action = scenario.Action('do_backup', params={'a': 'b'})
     ctx = scenario.Context(MyCharm)
 
     # If the parameters (or their type) don't match what is declared in the metadata, 
     # the `ConsistencyChecker` will slap you on the other wrist.
-    out: scenario.ActionOutput = ctx.run_action(action, scenario.State())
+    out: scenario.ActionOutput = ctx.run_action(
+        ctx.on.action("do_backup", params={'a': 'b'}),
+        scenario.State()
+    )
 
     # ...
 ```

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -308,6 +308,7 @@ nitpick_ignore = [
     # Please keep this list sorted alphabetically.
     ('py:class', 'AnyJson'),
     ('py:class', '_CharmSpec'),
+    ('py:class', '_Event'),
     ('py:class', 'scenario.state._DCBase'),
     ('py:class', 'scenario.state._EntityStatus'),
 ]

--- a/scenario/__init__.py
+++ b/scenario/__init__.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 from scenario.context import ActionOutput, Context
 from scenario.state import (
-    Action,
     ActiveStatus,
     Address,
     BindAddress,
@@ -37,7 +36,6 @@ from scenario.state import (
 )
 
 __all__ = [
-    "Action",
     "ActionOutput",
     "CloudCredential",
     "CloudSpec",

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING, Iterable, List, NamedTuple, Tuple, Union
 from scenario.runtime import InconsistentScenarioError
 from scenario.runtime import logger as scenario_logger
 from scenario.state import (
-    Action,
     PeerRelation,
     SubordinateRelation,
+    _Action,
     _CharmSpec,
     normalize_name,
 )
@@ -274,7 +274,7 @@ def _check_storage_event(
 
 def _check_action_param_types(
     charm_spec: _CharmSpec,
-    action: Action,
+    action: _Action,
     errors: List[str],
     warnings: List[str],
 ):

--- a/scenario/context.py
+++ b/scenario/context.py
@@ -12,11 +12,11 @@ from ops import CharmBase, EventBase
 from scenario.logger import logger as scenario_logger
 from scenario.runtime import Runtime
 from scenario.state import (
-    Action,
     Container,
     MetadataNotFoundError,
     Secret,
     Storage,
+    _Action,
     _CharmSpec,
     _Event,
     _max_posargs,
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ops.testing import CharmType
 
     from scenario.ops_main_mock import Ops
-    from scenario.state import AnyRelation, JujuLogLine, State, _EntityStatus
+    from scenario.state import AnyJson, AnyRelation, JujuLogLine, State, _EntityStatus
 
     PathLike = Union[str, Path]
 
@@ -81,7 +81,7 @@ class _Manager:
     def __init__(
         self,
         ctx: "Context",
-        arg: Union[str, Action, _Event],
+        arg: Union[str, _Action, _Event],
         state_in: "State",
     ):
         self._ctx = ctx
@@ -160,7 +160,7 @@ class _ActionManager(_Manager):
 
     @property
     def _runner(self):
-        return self._ctx._run_action  # noqa
+        return self._ctx._run  # noqa
 
     def _get_output(self):
         return self._ctx._finalize_action(self._ctx.output_state)  # noqa
@@ -311,6 +311,19 @@ class _CharmEvents:
     @staticmethod
     def pebble_ready(container: Container):
         return _Event(f"{container.name}_pebble_ready", container=container)
+
+    @staticmethod
+    def action(
+        name: str,
+        params: Optional[Dict[str, "AnyJson"]] = None,
+        id: Optional[str] = None,
+    ):
+        kwargs = {}
+        if params:
+            kwargs["params"] = params
+        if id:
+            kwargs["id"] = id
+        return _Event(f"{name}_action", action=_Action(name, **kwargs))
 
 
 class Context:
@@ -578,7 +591,7 @@ class Context:
         """
         return _EventManager(self, event, state)
 
-    def action_manager(self, action: "Action", state: "State"):
+    def action_manager(self, action: "_Action", state: "State"):
         """Context manager to introspect live charm object before and after the event is emitted.
 
         Usage:
@@ -608,23 +621,23 @@ class Context:
         :arg state: the State instance to use as data source for the hook tool calls that the
             charm will invoke when handling the Event.
         """
-        if isinstance(event, Action) or event.action:
+        if isinstance(event, _Action) or event.action:
             raise InvalidEventError("Use run_action() to run an action event.")
         with self._run_event(event=event, state=state) as ops:
             ops.emit()
         return self.output_state
 
-    def run_action(self, action: "Action", state: "State") -> ActionOutput:
-        """Trigger a charm execution with an Action and a State.
+    def run_action(self, event: "_Event", state: "State") -> ActionOutput:
+        """Trigger a charm execution with an action event and a State.
 
         Calling this function will call ``ops.main`` and set up the context according to the
         specified ``State``, then emit the event on the charm.
 
-        :arg action: the Action that the charm will execute.
+        :arg event: the action event that the charm will execute.
         :arg state: the State instance to use as data source for the hook tool calls that the
-            charm will invoke when handling the Action (event).
+            charm will invoke when handling the action event.
         """
-        with self._run_action(action=action, state=state) as ops:
+        with self._run(event=event, state=state) as ops:
             ops.emit()
         return self._finalize_action(self.output_state)
 
@@ -642,11 +655,6 @@ class Context:
         self._action_failure = None
 
         return ao
-
-    @contextmanager
-    def _run_action(self, action: "Action", state: "State"):
-        with self._run(event=action.event, state=state) as ops:
-            yield ops
 
     @contextmanager
     def _run(self, event: "_Event", state: "State"):

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1658,7 +1658,7 @@ class _Event:
     notice: Optional[Notice] = None
     """If this is a Pebble notice event, the notice it refers to."""
 
-    action: Optional["Action"] = None
+    action: Optional["_Action"] = None
     """If this is an action event, the :class:`Action` it refers to."""
 
     _owner_path: List[str] = dataclasses.field(default_factory=list)
@@ -1815,15 +1815,17 @@ def next_action_id(*, update=True):
 
 
 @dataclasses.dataclass(frozen=True)
-class Action(_max_posargs(1)):
+class _Action(_max_posargs(1)):
     """A ``juju run`` command.
 
     Used to simulate ``juju run``, passing in any parameters. For example::
 
         def test_backup_action():
-            action = scenario.Action('do_backup', params={'filename': 'foo'})
             ctx = scenario.Context(MyCharm)
-            out: scenario.ActionOutput = ctx.run_action(action, scenario.State())
+            out: scenario.ActionOutput = ctx.run_action(
+                ctx.on.action('do_backup', params={'filename': 'foo'}),
+                scenario.State()
+            )
     """
 
     name: str
@@ -1837,11 +1839,6 @@ class Action(_max_posargs(1)):
 
     Every action invocation is automatically assigned a new one. Override in
     the rare cases where a specific ID is required."""
-
-    @property
-    def event(self) -> _Event:
-        """Helper to generate an action event from this action."""
-        return _Event(self.name + ACTION_EVENT_SUFFIX, action=self)
 
 
 def deferred(

--- a/tests/test_context_on.py
+++ b/tests/test_context_on.py
@@ -173,8 +173,7 @@ def test_action_event_no_params():
     ctx = scenario.Context(ContextCharm, meta=META, actions=ACTIONS)
     # These look like:
     #   ctx.run_action(ctx.on.action(action), state)
-    action = scenario.Action("act")
-    with ctx.action_manager(action, scenario.State()) as mgr:
+    with ctx.action_manager(ctx.on.action("act"), scenario.State()) as mgr:
         mgr.run()
         assert len(mgr.charm.observed) == 2
         assert isinstance(mgr.charm.observed[1], ops.CollectStatusEvent)
@@ -184,18 +183,18 @@ def test_action_event_no_params():
 
 def test_action_event_with_params():
     ctx = scenario.Context(ContextCharm, meta=META, actions=ACTIONS)
-    action = scenario.Action("act", params={"param": "hello"})
     # These look like:
     #   ctx.run_action(ctx.on.action(action=action), state)
     # So that any parameters can be included and the ID can be customised.
-    with ctx.action_manager(action, scenario.State()) as mgr:
+    call_event = ctx.on.action("act", params={"param": "hello"})
+    with ctx.action_manager(call_event, scenario.State()) as mgr:
         mgr.run()
         assert len(mgr.charm.observed) == 2
         assert isinstance(mgr.charm.observed[1], ops.CollectStatusEvent)
         event = mgr.charm.observed[0]
         assert isinstance(event, ops.ActionEvent)
-        assert event.id == action.id
-        assert event.params["param"] == action.params["param"]
+        assert event.id == call_event.action.id
+        assert event.params["param"] == call_event.action.params["param"]
 
 
 def test_pebble_ready_event():

--- a/tests/test_e2e/test_manager.py
+++ b/tests/test_e2e/test_manager.py
@@ -4,7 +4,7 @@ import pytest
 from ops import ActiveStatus
 from ops.charm import CharmBase, CollectStatusEvent
 
-from scenario import Action, Context, State
+from scenario import Context, State
 from scenario.context import ActionOutput, AlreadyEmittedError, _EventManager
 
 
@@ -73,7 +73,7 @@ def test_context_manager(mycharm):
 
 def test_context_action_manager(mycharm):
     ctx = Context(mycharm, meta=mycharm.META, actions=mycharm.ACTIONS)
-    with ctx.action_manager(Action("do-x"), State()) as manager:
+    with ctx.action_manager(ctx.on.action("do-x"), State()) as manager:
         ao = manager.run()
         assert isinstance(ao, ActionOutput)
     assert ctx.emitted_events[0].handle.kind == "do_x_action"


### PR DESCRIPTION
This adjusts emitting action events to align with emitting other events.

When needing to pass params, instead of having to create an `Action` object, these can just be passed in the run call in the same way that extra parameters for notices, relations, etc are. When using params, the code is about the same size - when there are no parameters it's a little longer than just having a string, but much more consistent, both with the other events, and with using observe.

Example:

```python
# Non-action event
ctx = Context(MyCharm)
ctx.run(ctx.on.start(), State())

# Action event, no params
ctx = Context(MyCharm)
ctx.run(ctx.on.action("foo"), State())

# Action event, params
ctx = Context(MyCharm)
ctx.run(ctx.on.action("foo", params={"bar": 123}), State())
```