### PR TITLE
feat!: move default network into Network()

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ remote_unit_2_is_joining_event = ctx.on.relation_joined(relation, remote_unit=2)
 Simplifying a bit the Juju "spaces" model, each integration endpoint a charm defines in its metadata is associated with a network. Regardless of whether there is a living relation over that endpoint, that is.  
 
 If your charm has a relation `"foo"` (defined in its metadata), then the charm will be able at runtime to do `self.model.get_binding("foo").network`.
-The network you'll get by doing so is heavily defaulted (see `state.Network.default`) and good for most use-cases because the charm should typically not be concerned about what IP it gets. 
+The network you'll get by doing so is heavily defaulted (see `state.Network`) and good for most use-cases because the charm should typically not be concerned about what IP it gets. 
 
 On top of the relation-provided network bindings, a charm can also define some `extra-bindings` in its metadata and access them at runtime. Note that this is a deprecated feature that should not be relied upon. For completeness, we support it in Scenario.
 
@@ -496,7 +496,7 @@ If you want to, you can override any of these relation or extra-binding associat
 
 ```python
 state = scenario.State(networks={
-  scenario.Network.default("foo", private_address='192.0.2.1')
+  scenario.Network("foo", [BindAddress([Address('192.0.2.1')])])
 })
 ```
 

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -317,7 +317,7 @@ class _MockModelBackend(_ModelBackend):
         try:
             network = self._state.get_network(binding_name)
         except KeyError:
-            network = Network.default("default")  # The name is not used in the output.
+            network = Network("default")  # The name is not used in the output.
         return network.hook_tool_output_fmt()
 
     # setter methods: these can mutate the state.

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -338,11 +338,11 @@ def normalize_name(s: str):
 class Address(_max_posargs(1)):
     """An address in a Juju network space."""
 
-    hostname: str
-    """A host name that maps to the address in :attr:`value`."""
     value: str
     """The IP address in the space."""
-    cidr: str
+    hostname: str = ""
+    """A host name that maps to the address in :attr:`value`."""
+    cidr: str = ""
     """The CIDR of the address in :attr:`value`."""
 
     @property
@@ -376,11 +376,17 @@ class BindAddress(_max_posargs(1)):
 
 
 @dataclasses.dataclass(frozen=True)
-class Network(_max_posargs(1)):
+class Network(_max_posargs(2)):
     binding_name: str
-    bind_addresses: List[BindAddress]
-    ingress_addresses: List[str]
-    egress_subnets: List[str]
+    bind_addresses: List[BindAddress] = dataclasses.field(
+        default_factory=lambda: [BindAddress([Address("192.0.2.0")])],
+    )
+    ingress_addresses: List[str] = dataclasses.field(
+        default_factory=lambda: ["192.0.2.0"],
+    )
+    egress_subnets: List[str] = dataclasses.field(
+        default_factory=lambda: ["192.0.2.0/24"],
+    )
 
     def __hash__(self) -> int:
         return hash(self.binding_name)
@@ -392,34 +398,6 @@ class Network(_max_posargs(1)):
             "egress-subnets": self.egress_subnets,
             "ingress-addresses": self.ingress_addresses,
         }
-
-    @classmethod
-    def default(
-        cls,
-        binding_name: str,
-        private_address: str = "192.0.2.0",
-        hostname: str = "",
-        cidr: str = "",
-        interface_name: str = "",
-        mac_address: Optional[str] = None,
-        egress_subnets=("192.0.2.0/24",),
-        ingress_addresses=("192.0.2.0",),
-    ) -> "Network":
-        """Helper to create a minimal, heavily defaulted Network."""
-        return cls(
-            binding_name=binding_name,
-            bind_addresses=[
-                BindAddress(
-                    interface_name=interface_name,
-                    mac_address=mac_address,
-                    addresses=[
-                        Address(hostname=hostname, value=private_address, cidr=cidr),
-                    ],
-                ),
-            ],
-            egress_subnets=list(egress_subnets),
-            ingress_addresses=list(ingress_addresses),
-        )
 
 
 _next_relation_id_counter = 1

--- a/tests/test_consistency_checker.py
+++ b/tests/test_consistency_checker.py
@@ -634,7 +634,7 @@ def test_resource_states():
 
 def test_networks_consistency():
     assert_inconsistent(
-        State(networks={Network.default("foo")}),
+        State(networks={Network("foo")}),
         _Event("start"),
         _CharmSpec(
             MyCharm,
@@ -643,7 +643,7 @@ def test_networks_consistency():
     )
 
     assert_inconsistent(
-        State(networks={Network.default("foo")}),
+        State(networks={Network("foo")}),
         _Event("start"),
         _CharmSpec(
             MyCharm,
@@ -656,7 +656,7 @@ def test_networks_consistency():
     )
 
     assert_consistent(
-        State(networks={Network.default("foo")}),
+        State(networks={Network("foo")}),
         _Event("start"),
         _CharmSpec(
             MyCharm,

--- a/tests/test_e2e/test_network.py
+++ b/tests/test_e2e/test_network.py
@@ -4,7 +4,14 @@ from ops.charm import CharmBase
 from ops.framework import Framework
 
 from scenario import Context
-from scenario.state import Network, Relation, State, SubordinateRelation
+from scenario.state import (
+    Address,
+    BindAddress,
+    Network,
+    Relation,
+    State,
+    SubordinateRelation,
+)
 
 
 @pytest.fixture(scope="function")
@@ -51,7 +58,7 @@ def test_ip_get(mycharm):
                     id=1,
                 ),
             ],
-            networks={Network.default("foo", private_address="4.4.4.4")},
+            networks={Network("foo", [BindAddress([Address("4.4.4.4")])])},
         ),
     ) as mgr:
         # we have a network for the relation
@@ -113,7 +120,7 @@ def test_no_relation_error(mycharm):
                     id=1,
                 ),
             ],
-            networks={Network.default("bar")},
+            networks={Network("bar")},
         ),
     ) as mgr:
         with pytest.raises(RelationNotFoundError):

--- a/tests/test_e2e/test_state.py
+++ b/tests/test_e2e/test_state.py
@@ -253,7 +253,7 @@ def test_relation_set(mycharm):
         (Resource, (1,)),
         (Address, (0, 2)),
         (BindAddress, (0, 2)),
-        (Network, (1, 2)),
+        (Network, (0, 3)),
     ],
 )
 def test_positional_arguments(klass, num_args):


### PR DESCRIPTION
This moves the default Network into the `Network` initialisation, rather than as a separate classmethod that provides a `Network` object. This is more consistent with the rest of the Scenario objects, which try to have useful defaults where possible.

For the most simple case:

```python
# Previously
network = Network.default()
# Now
network = Network("default")  # The name is needed because of the `State` change elsewhere
```

To override elements of the default is a little bit more work, particularly if it's in the nested `Address` object, but it doesn't seem too bad:

```python
# Previously
network = Network.default(private_address="129.0.2.1")
# Now
network = Network("foo", [BindAddress([Address("129.0.2.1")])])
```