### PR TITLE
fixed juju-info network

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "6.1.3"
+version = "6.1.4"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/consistency_checker.py
+++ b/scenario/consistency_checker.py
@@ -427,6 +427,9 @@ def check_network_consistency(
     errors = []
 
     meta_bindings = set(charm_spec.meta.get("extra-bindings", ()))
+    # add the implicit juju-info binding so we can override its network without
+    # having to declare a relation for it in metadata
+    meta_bindings.add("juju-info")
     all_relations = charm_spec.get_all_relations()
     non_sub_relations = {
         endpoint

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -298,6 +298,9 @@ class _MockModelBackend(_ModelBackend):
                     "cannot pass relation_id to network_get if the binding name is "
                     "that of an extra-binding. Extra-bindings are not mapped to relation IDs.",
                 )
+        elif binding_name == "juju-info":
+            # implicit relation that always exists
+            pass
         # - verify that the binding is a relation endpoint name, but not a subordinate one
         elif binding_name not in non_sub_relations:
             logger.error(

--- a/tests/test_e2e/test_network.py
+++ b/tests/test_e2e/test_network.py
@@ -117,7 +117,7 @@ def test_no_relation_error(mycharm):
         ),
     ) as mgr:
         with pytest.raises(RelationNotFoundError):
-            net = mgr.charm.model.get_binding("foo").network
+            mgr.charm.model.get_binding("foo").network
 
 
 def test_juju_info_network_default(mycharm):

--- a/tests/test_e2e/test_network.py
+++ b/tests/test_e2e/test_network.py
@@ -118,3 +118,39 @@ def test_no_relation_error(mycharm):
     ) as mgr:
         with pytest.raises(RelationNotFoundError):
             net = mgr.charm.model.get_binding("foo").network
+
+
+def test_juju_info_network_default(mycharm):
+    ctx = Context(
+        mycharm,
+        meta={"name": "foo"},
+    )
+
+    with ctx.manager(
+        "update_status",
+        State(),
+    ) as mgr:
+        # we have a network for the relation
+        assert (
+            str(mgr.charm.model.get_binding("juju-info").network.bind_address)
+            == "192.0.2.0"
+        )
+
+
+def test_juju_info_network_override(mycharm):
+    ctx = Context(
+        mycharm,
+        meta={"name": "foo"},
+    )
+
+    with ctx.manager(
+        "update_status",
+        State(
+            networks={"juju-info": Network.default(private_address="4.4.4.4")},
+        ),
+    ) as mgr:
+        # we have a network for the relation
+        assert (
+            str(mgr.charm.model.get_binding("juju-info").network.bind_address)
+            == "4.4.4.4"
+        )


### PR DESCRIPTION
Special-cases network-get for the `juju-info` relation so that it won't raise if no binding with that name is found in the charm metadata.

User can still override the network by passing it to `State.networks`.

Fixes #164 

