### PR TITLE
fix: update secret label when getting with both id and label

### DIFF
--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -401,6 +401,9 @@ class _MockModelBackend(_ModelBackend):
         peek: bool = False,
     ) -> Dict[str, str]:
         secret = self._get_secret(id, label)
+        # If both the id and label are provided, then update the label.
+        if id is not None and label is not None:
+            secret._set_label(label)
         juju_version = self._context.juju_version
         if not (juju_version == "3.1.7" or juju_version >= "3.3.1"):
             # In this medieval Juju chapter,
@@ -424,6 +427,9 @@ class _MockModelBackend(_ModelBackend):
         label: Optional[str] = None,
     ) -> SecretInfo:
         secret = self._get_secret(id, label)
+        # If both the id and label are provided, then update the label.
+        if id is not None and label is not None:
+            secret._set_label(label)
 
         # only "manage"=write access level can read secret info
         self._check_can_manage_secret(secret)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -321,6 +321,10 @@ class Secret(_max_posargs(1)):
             # bypass frozen dataclass
             object.__setattr__(self, "latest_content", self.tracked_content)
 
+    def _set_label(self, label):
+        # bypass frozen dataclass
+        object.__setattr__(self, "label", label)
+
     def _track_latest_revision(self):
         """Set the current revision to the tracked revision."""
         # bypass frozen dataclass
@@ -340,6 +344,7 @@ class Secret(_max_posargs(1)):
         object.__setattr__(self, "_latest_revision", self._latest_revision + 1)
         # TODO: if this is done twice in the same hook, then Juju ignores the
         # first call, it doesn't continue to update like this does.
+        # Fix when https://github.com/canonical/operator/issues/1288 is resolved.
         if content:
             object.__setattr__(self, "latest_content", content)
         if label:

--- a/tests/test_e2e/test_secrets.py
+++ b/tests/test_e2e/test_secrets.py
@@ -567,6 +567,24 @@ def test_remove_bad_revision():
     )
 
 
+def test_set_label_on_get():
+    class SecretCharm(CharmBase):
+        def __init__(self, framework):
+            super().__init__(framework)
+            self.framework.observe(self.on.start, self._on_start)
+
+        def _on_start(self, _):
+            id = self.unit.add_secret({"foo": "bar"}).id
+            secret = self.model.get_secret(id=id, label="label1")
+            assert secret.label == "label1"
+            secret = self.model.get_secret(id=id, label="label2")
+            assert secret.label == "label2"
+
+    ctx = Context(SecretCharm, meta={"name": "foo"})
+    state = ctx.run(ctx.on.start(), State())
+    assert state.get_secret(label="label2").tracked_content == {"foo": "bar"}
+
+
 def test_no_additional_positional_arguments():
     with pytest.raises(TypeError):
         Secret({}, {}, None)


### PR DESCRIPTION
When we get a secret and provide both ID and label, the label should update to the provided one. This was previously missing in Scenario.

Fixes #95