### PR TITLE
feat!: simplify creating deferred events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,7 +1063,7 @@ class MyCharm(ops.CharmBase):
         event.defer()
 
 
-def test_start_on_deferred_update_status(MyCharm):
+def test_start_on_deferred_update_status():
     """Test charm execution if a 'start' is dispatched when in the previous run an update-status had been deferred."""
     ctx = scenario.Context(MyCharm)
     state_in = scenario.State(

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ with scenario.capture_events.capture_events() as emitted:
     ctx = scenario.Context(SimpleCharm, meta={"name": "capture"})
     state_out = ctx.run(
         ctx.on.update_status(),
-        scenario.State(deferred=[scenario.deferred("start", SimpleCharm._on_start)])
+        scenario.State(deferred=[ctx.on.start().deferred(SimpleCharm._on_start)])
     )
 
 # deferred events get reemitted first
@@ -1050,7 +1050,7 @@ def test_backup_action():
 Scenario allows you to accurately simulate the Operator Framework's event queue. The event queue is responsible for
 keeping track of the deferred events. On the input side, you can verify that if the charm triggers with this and that
 event in its queue (they would be there because they had been deferred in the previous run), then the output state is
-valid.
+valid. You generate the deferred data structure using the event's `deferred()` method:
 
 ```python
 class MyCharm(ops.CharmBase):
@@ -1065,24 +1065,15 @@ class MyCharm(ops.CharmBase):
 
 def test_start_on_deferred_update_status(MyCharm):
     """Test charm execution if a 'start' is dispatched when in the previous run an update-status had been deferred."""
+    ctx = scenario.Context(MyCharm)
     state_in = scenario.State(
         deferred=[
-            scenario.deferred('update_status', handler=MyCharm._on_update_status)
+            ctx.on.update_status().deferred(handler=MyCharm._on_update_status)
         ]
     )
-    state_out = scenario.Context(MyCharm).run(ctx.on.start(), state_in)
+    state_out = ctx.run(ctx.on.start(), state_in)
     assert len(state_out.deferred) == 1
     assert state_out.deferred[0].name == 'start'
-```
-
-You can also generate the 'deferred' data structure (called a DeferredEvent) from the corresponding Event (and the
-handler):
-
-```python continuation
-ctx = scenario.Context(MyCharm, meta={"name": "deferring"})
-
-deferred_start = ctx.on.start().deferred(MyCharm._on_start)
-deferred_install = ctx.on.install().deferred(MyCharm._on_start)
 ```
 
 On the output side, you can verify that an event that you expect to have been deferred during this trigger, has indeed
@@ -1100,41 +1091,6 @@ def test_defer(MyCharm):
     out = scenario.Context(MyCharm).run(ctx.on.start(), scenario.State())
     assert len(out.deferred) == 1
     assert out.deferred[0].name == 'start'
-```
-
-## Deferring relation events
-
-If you want to test relation event deferrals, some extra care needs to be taken. RelationEvents hold references to the
-Relation instance they are about. So do they in Scenario. You can use the deferred helper to generate the data
-structure:
-
-```python
-class MyCharm(ops.CharmBase):
-    ...
-
-    def _on_foo_relation_changed(self, event):
-        event.defer()
-
-
-def test_start_on_deferred_update_status(MyCharm):
-    foo_relation = scenario.Relation('foo')
-    scenario.State(
-        relations={foo_relation},
-        deferred=[
-            scenario.deferred('foo_relation_changed',
-                              handler=MyCharm._on_foo_relation_changed,
-                              relation=foo_relation)
-        ]
-    )
-```
-
-but you can also use a shortcut from the relation event itself:
-
-```python continuation
-ctx = scenario.Context(MyCharm, meta={"name": "deferring"})
-
-foo_relation = scenario.Relation('foo')
-deferred_event = ctx.on.relation_changed(foo_relation).deferred(handler=MyCharm._on_foo_relation_changed)
 ```
 
 # Live charm introspection

--- a/scenario/__init__.py
+++ b/scenario/__init__.py
@@ -35,7 +35,6 @@ from scenario.state import (
     UDPPort,
     UnknownStatus,
     WaitingStatus,
-    deferred,
 )
 
 __all__ = [
@@ -44,7 +43,6 @@ __all__ = [
     "CloudCredential",
     "CloudSpec",
     "Context",
-    "deferred",
     "StateValidationError",
     "Secret",
     "Relation",

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1559,7 +1559,7 @@ class DeferredEvent:
     instead. For example:
 
         ctx = Context(MyCharm)
-        deferred_start = ctx.on.start().deferred()
+        deferred_start = ctx.on.start().deferred(handler=MyCharm._on_start)
         state = State(deferred=[deferred_start])
     """
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1792,6 +1792,7 @@ class _Event:
         #  not, then the coming checks are meaningless: the custom event could be named like a
         #  relation event but not *be* one.
         if self._is_workload_event:
+            # Enforced by the consistency checker, but for type checkers:
             assert self.container is not None
             snapshot_data["container_name"] = self.container.name
             if self.notice:
@@ -1810,6 +1811,7 @@ class _Event:
                 snapshot_data["check_name"] = self.check_info.name
 
         elif self._is_relation_event:
+            # Enforced by the consistency checker, but for type checkers:
             assert self.relation is not None
             relation = self.relation
             if isinstance(relation, PeerRelation):
@@ -1836,6 +1838,7 @@ class _Event:
                 ] = f"{remote_app}/{self.relation_departed_unit_id}"
 
         elif self._is_storage_event:
+            # Enforced by the consistency checker, but for type checkers:
             assert self.storage is not None
             snapshot_data.update(
                 {
@@ -1846,6 +1849,7 @@ class _Event:
             )
 
         elif self._is_secret_event:
+            # Enforced by the consistency checker, but for type checkers:
             assert self.secret is not None
             snapshot_data.update(
                 {"secret_id": self.secret.id, "secret_label": self.secret.label},
@@ -1854,6 +1858,7 @@ class _Event:
                 snapshot_data["secret_revision"] = self.secret_revision
 
         elif self._is_action_event:
+            # Enforced by the consistency checker, but for type checkers:
             assert self.action is not None
             snapshot_data["id"] = self.action.id
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1555,8 +1555,13 @@ class _CharmSpec(Generic[CharmType]):
 class DeferredEvent:
     """An event that has been deferred to run prior to the next Juju event.
 
-    In most cases, the :func:`deferred` function should be used to create a
-    ``DeferredEvent`` instance."""
+    Tests should not instantiate this class directly: use :meth:`_Event.deferred`
+    instead. For example:
+
+        ctx = Context(MyCharm)
+        deferred_start = ctx.on.start().deferred()
+        state = State(deferred=[deferred_start])
+    """
 
     handle_path: str
     owner: str
@@ -1862,24 +1867,3 @@ class _Action(_max_posargs(1)):
 
     Every action invocation is automatically assigned a new one. Override in
     the rare cases where a specific ID is required."""
-
-
-def deferred(
-    event: Union[str, _Event],
-    handler: Callable,
-    event_id: int = 1,
-    relation: Optional["Relation"] = None,
-    container: Optional["Container"] = None,
-    notice: Optional["Notice"] = None,
-    check_info: Optional["CheckInfo"] = None,
-):
-    """Construct a DeferredEvent from an Event or an event name."""
-    if isinstance(event, str):
-        event = _Event(
-            event,
-            relation=relation,
-            container=container,
-            notice=notice,
-            check_info=check_info,
-        )
-    return event.deferred(handler=handler, event_id=event_id)

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1570,12 +1570,18 @@ class DeferredEvent:
     # needs to be marshal.dumps-able.
     snapshot_data: Dict = dataclasses.field(default_factory=dict)
 
+    # It would be nicer if people could do something like:
+    #   `isinstance(state.deferred[0], ops.StartEvent)`
+    # than comparing with the string names, but there's only one `_Event`
+    # class in Scenario, and it also needs to be created from the context,
+    # which is not available here. For the ops classes, it's complex to create
+    # them because they need a Handle.
     @property
     def name(self):
         return self.handle_path.split("/")[-1].split("[")[0]
 
 
-class _EventType(str, Enum):
+class _EventType(str, Enum):  #
     framework = "framework"
     builtin = "builtin"
     relation = "relation"
@@ -1777,17 +1783,17 @@ class _Event:
         owner_name, handler_name = match.groups()[0].split(".")[-2:]
         handle_path = f"{owner_name}/on/{self.name}[{event_id}]"
 
+        # Many events have no snapshot data: install, start, stop, remove, config-changed,
+        # upgrade-charm, pre-series-upgrade, post-series-upgrade, leader-elected,
+        # leader-settings-changed, collect-metrics
         snapshot_data = {}
 
         # fixme: at this stage we can't determine if the event is a builtin one or not; if it is
         #  not, then the coming checks are meaningless: the custom event could be named like a
         #  relation event but not *be* one.
         if self._is_workload_event:
-            # this is a WorkloadEvent. The snapshot:
-            container = cast(Container, self.container)
-            snapshot_data = {
-                "container_name": container.name,
-            }
+            assert self.container is not None
+            snapshot_data["container_name"] = self.container.name
             if self.notice:
                 if hasattr(self.notice.type, "value"):
                     notice_type = cast(pebble.NoticeType, self.notice.type).value
@@ -1804,8 +1810,8 @@ class _Event:
                 snapshot_data["check_name"] = self.check_info.name
 
         elif self._is_relation_event:
-            # this is a RelationEvent.
-            relation = cast("AnyRelation", self.relation)
+            assert self.relation is not None
+            relation = self.relation
             if isinstance(relation, PeerRelation):
                 # FIXME: relation.unit for peers should point to <this unit>, but we
                 #  don't have access to the local app name in this context.
@@ -1813,12 +1819,43 @@ class _Event:
             else:
                 remote_app = relation.remote_app_name
 
-            snapshot_data = {
-                "relation_name": relation.endpoint,
-                "relation_id": relation.id,
-                "app_name": remote_app,
-                "unit_name": f"{remote_app}/{self.relation_remote_unit_id}",
-            }
+            snapshot_data.update(
+                {
+                    "relation_name": relation.endpoint,
+                    "relation_id": relation.id,
+                    "app_name": remote_app,
+                },
+            )
+            if not self.name.endswith(("_created", "_broken")):
+                snapshot_data[
+                    "unit_name"
+                ] = f"{remote_app}/{self.relation_remote_unit_id}"
+            if self.name.endswith("_departed"):
+                snapshot_data[
+                    "departing_unit"
+                ] = f"{remote_app}/{self.relation_departed_unit_id}"
+
+        elif self._is_storage_event:
+            assert self.storage is not None
+            snapshot_data.update(
+                {
+                    "storage_name": self.storage.name,
+                    "storage_index": self.storage.index,
+                    # "storage_location": str(self.storage.get_filesystem(self._context)),
+                },
+            )
+
+        elif self._is_secret_event:
+            assert self.secret is not None
+            snapshot_data.update(
+                {"secret_id": self.secret.id, "secret_label": self.secret.label},
+            )
+            if self.name.endswith(("_remove", "_expired")):
+                snapshot_data["secret_revision"] = self.secret_revision
+
+        elif self._is_action_event:
+            assert self.action is not None
+            snapshot_data["id"] = self.action.id
 
         return DeferredEvent(
             handle_path,

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -1581,7 +1581,7 @@ class DeferredEvent:
         return self.handle_path.split("/")[-1].split("[")[0]
 
 
-class _EventType(str, Enum):  #
+class _EventType(str, Enum):
     framework = "framework"
     builtin = "builtin"
     relation = "relation"

--- a/tests/test_e2e/test_deferred.py
+++ b/tests/test_e2e/test_deferred.py
@@ -12,7 +12,7 @@ from ops.charm import (
 from ops.framework import Framework
 
 from scenario import Context
-from scenario.state import Container, Notice, Relation, State, _Event, deferred
+from scenario.state import Container, Notice, Relation, State, _Event
 from tests.helpers import trigger
 
 CHARM_CALLED = 0
@@ -54,7 +54,7 @@ def test_deferred_evt_emitted(mycharm):
     mycharm.defer_next = 2
 
     out = trigger(
-        State(deferred=[deferred(event="update_status", handler=mycharm._on_event)]),
+        State(deferred=[_Event("update_status").deferred(handler=mycharm._on_event)]),
         "start",
         mycharm,
         meta=mycharm.META,
@@ -72,49 +72,6 @@ def test_deferred_evt_emitted(mycharm):
     assert isinstance(start, StartEvent)
 
 
-def test_deferred_relation_event_without_relation_raises(mycharm):
-    with pytest.raises(AttributeError):
-        deferred(event="foo_relation_changed", handler=mycharm._on_event)
-
-
-def test_deferred_relation_evt(mycharm):
-    rel = Relation(endpoint="foo", remote_app_name="remote")
-    evt1 = _Event("foo_relation_changed", relation=rel).deferred(
-        handler=mycharm._on_event
-    )
-    evt2 = deferred(
-        event="foo_relation_changed",
-        handler=mycharm._on_event,
-        relation=rel,
-    )
-
-    assert asdict(evt2) == asdict(evt1)
-
-
-def test_deferred_workload_evt(mycharm):
-    ctr = Container("foo")
-    evt1 = _Event("foo_pebble_ready", container=ctr).deferred(handler=mycharm._on_event)
-    evt2 = deferred(event="foo_pebble_ready", handler=mycharm._on_event, container=ctr)
-
-    assert asdict(evt2) == asdict(evt1)
-
-
-def test_deferred_notice_evt(mycharm):
-    notice = Notice(key="example.com/bar")
-    ctr = Container("foo", notices=[notice])
-    evt1 = _Event("foo_pebble_custom_notice", notice=notice, container=ctr).deferred(
-        handler=mycharm._on_event
-    )
-    evt2 = deferred(
-        event="foo_pebble_custom_notice",
-        handler=mycharm._on_event,
-        container=ctr,
-        notice=notice,
-    )
-
-    assert asdict(evt2) == asdict(evt1)
-
-
 def test_deferred_relation_event(mycharm):
     mycharm.defer_next = 2
 
@@ -124,10 +81,8 @@ def test_deferred_relation_event(mycharm):
         State(
             relations={rel},
             deferred=[
-                deferred(
-                    event="foo_relation_changed",
+                _Event("foo_relation_changed", relation=rel).deferred(
                     handler=mycharm._on_event,
-                    relation=rel,
                 )
             ],
         ),


### PR DESCRIPTION
A couple of changes to simplify setting up the queue of deferred events:

* Adjusted the docs for `DeferredEvent` to strongly suggest that it's for internal use only and people should use the `.deferred()` method of an `_Event` instead. It's still required internally (to go to/from the ops state) and might be needed in obscure cases, but this reduces the number of ways people need to be aware of by one.
* The `scenario.deferred()` helper is removed. When using this method for events that link to components (relations, containers, etc) it was possible to not have the event set up correctly, and it didn't really seem to offer much over `.deferred()`. Removing it leaves one normal way to create deferred events.

Finally, setting up the `DeferredEvent` snapshot data only handled workload events and relation events (and wasn't always correct for all relation events). It should now cover all current events with the right snapshot.