### PR TITLE
chore: add compatibility with the next ops release

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "cSpell.words": [
-        "Catan",
-        "deepcopy",
-        "jsonpatch"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "Catan",
+        "deepcopy",
+        "jsonpatch"
+    ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "6.1.2"
+version = "6.1.6"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }


### PR DESCRIPTION
The next release of ops has some backwards-incompatible changes to private methods. This PR does the minimum to keep Scenario working with the current version of ops and the next release.

I'll open a ticket for doing a nicer version of this where the new `_JujuContext` class is used (which would presumably mean requiring the new version of ops). But this will let people continue upgrading their ops as long as they're using the latest 6.x of Scenario.

The relevant ops PR is: https://github.com/canonical/operator/pull/1313