### PR TITLE
chore: limit Scenario 6 to use ops 2.12-2.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "6.1.6"
+version = "6.1.7"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops>=2.12",
+    "ops>=2.12,<=2.16",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -88,7 +88,7 @@ def _emit_charm_event(
         )
 
     try:
-        args, kwargs = _get_event_args(charm, event_to_emit)
+        args, kwargs = _get_event_args(charm, event_to_emit)  # type: ignore
     except TypeError:
         # ops 2.16+
         import ops.jujucontext  # type: ignore
@@ -182,7 +182,7 @@ def setup(state: "State", event: "Event", context: "Context", charm_spec: "_Char
     charm_dir = _get_charm_dir()
 
     try:
-        dispatcher = _Dispatcher(charm_dir)
+        dispatcher = _Dispatcher(charm_dir)  # type: ignore
     except TypeError:
         # ops 2.16+
         import ops.jujucontext  # type: ignore


### PR DESCRIPTION
This hopefully avoids needing to do a 6.1.x release to fix compatibility with any upcoming ops release.