### PR TITLE
fix: adjust the inspect.signature behaviour to work with Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.0.0"
+version = "7.0.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -139,12 +139,13 @@ def _max_posargs(n: int):
             # declared, which aligns with dataclasses. Simpler ways of
             # getting the arguments (like __annotations__) do not have that
             # guarantee, although in practice it is the case.
-            parameters = inspect.signature(cls).parameters
+            parameters = inspect.signature(cls.__init__).parameters
             required_args = [
                 name
                 for name in tuple(parameters)
                 if parameters[name].default is inspect.Parameter.empty
                 and name not in kwargs
+                and name != "self"
             ]
             n_posargs = len(args)
             max_n_posargs = cls._max_positional_args


### PR DESCRIPTION
Python 3.9 changes the behaviour of `inspect.signature` - in 3.8 if a class has a parent with a `__new__` then the `__new__` is used when getting the class signature, and in 3.9 (and above) the class's `__init__` is used.

Instead of getting the class's signature, get the signature of `__init__` explicitly (ignoring `self`), so that this works in 3.8 as well as 3.9 and above.

I've done `uvx --python=3.{8,9,10,11,12} tox -e unit` , so things should be good now.

Fixes #187