### PR TITLE
chore: handle the changes coming in ops 2.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.0.1"
+version = "7.0.2"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -199,11 +199,20 @@ class _MockModelBackend(_ModelBackend):
             # in scenario, you can create Secret(id="foo"),
             # but ops.Secret will prepend a "secret:" prefix to that ID.
             # we allow getting secret by either version.
-            secrets = [
-                s
-                for s in self._state.secrets
-                if canonicalize_id(s.id) == canonicalize_id(id)
-            ]
+            try:
+                secrets = [
+                    s
+                    for s in self._state.secrets
+                    if canonicalize_id(s.id, model_uuid=self._state.model.uuid)  # type: ignore
+                    == canonicalize_id(id, model_uuid=self._state.model.uuid)  # type: ignore
+                ]
+            except TypeError:
+                # ops 2.16
+                secrets = [
+                    s
+                    for s in self._state.secrets
+                    if canonicalize_id(s.id) == canonicalize_id(id)  # type: ignore
+                ]
             if not secrets:
                 raise SecretNotFoundError(id)
             return secrets[0]

--- a/scenario/ops_main_mock.py
+++ b/scenario/ops_main_mock.py
@@ -12,12 +12,17 @@ import ops.framework
 import ops.model
 import ops.storage
 from ops import CharmBase
+
+# use logger from ops._main so that juju_log will be triggered
+try:
+    from ops._main import CHARM_STATE_FILE, _Dispatcher, _get_event_args  # type: ignore
+    from ops._main import logger as ops_logger  # type: ignore
+except ImportError:
+    # Ops 2.16
+    from ops.main import CHARM_STATE_FILE, _Dispatcher, _get_event_args  # type: ignore
+    from ops.main import logger as ops_logger  # type: ignore
 from ops.charm import CharmMeta
 from ops.log import setup_root_logging
-
-# use logger from ops.main so that juju_log will be triggered
-from ops.main import CHARM_STATE_FILE, _Dispatcher, _get_event_args
-from ops.main import logger as ops_logger
 
 from scenario.errors import BadOwnerPath, NoObserverError
 


### PR DESCRIPTION
The `Secret._canonicalize_id` method requires the model UUID to be passed in ops:main@HEAD.

There are some names that have moved from `ops.main` to `ops._main` - they are re-exported so Scenario doesn't actually break, but the static check complains if they are imported from `ops.main`.

This handles both current ops and ops 2.17 so that it can be merged ahead of the ops release, but the backwards compatibility should just get dropped and the minimum ops version bumped after the release, I think.