### PR TITLE
fix: ops.Model.get_relation should not raise when a relation with the specified ID does not exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.0.2"
+version = "7.0.3"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/mocking.py
+++ b/scenario/mocking.py
@@ -181,7 +181,7 @@ class _MockModelBackend(_ModelBackend):
     def _get_relation_by_id(self, rel_id) -> "RelationBase":
         try:
             return self._state.get_relation(rel_id)
-        except ValueError:
+        except KeyError:
             raise RelationNotFoundError() from None
 
     def _get_secret(self, id=None, label=None):

--- a/tests/test_e2e/test_relations.py
+++ b/tests/test_e2e/test_relations.py
@@ -412,6 +412,19 @@ def test_relation_ids():
         assert rel.id == initial_id + i
 
 
+def test_broken_relation_not_in_model_relations(mycharm):
+    rel = Relation("foo")
+
+    ctx = Context(
+        mycharm, meta={"name": "local", "requires": {"foo": {"interface": "foo"}}}
+    )
+    with ctx(ctx.on.relation_broken(rel), state=State(relations={rel})) as mgr:
+        charm = mgr.charm
+
+        assert charm.model.get_relation("foo") is None
+        assert charm.model.relations["foo"] == []
+
+
 def test_get_relation_when_missing():
     class MyCharm(CharmBase):
         def __init__(self, framework):


### PR DESCRIPTION
`State.get_relation` raises `KeyError` when no matching relation can be found, so adjust the mocking to expect that rather than `ValueError` as previously.

Add a test that validates the various results of `ops.Model.get_relation` when the relation doesn't exist.

Fixes #193