### PR TITLE
docs: fix incorrectly copied docstring, update Pebble docs link

### DIFF
--- a/scenario/context.py
+++ b/scenario/context.py
@@ -167,7 +167,7 @@ class CharmEvents:
         return _Event("config_changed")
 
     @staticmethod
-    @_copy_doc(ops.UpdateStatusEvent)
+    @_copy_doc(ops.UpgradeCharmEvent)
     def upgrade_charm():
         return _Event("upgrade_charm")
 

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -824,7 +824,7 @@ class Notice(_max_posargs(1)):
     last_repeated: datetime.datetime = dataclasses.field(default_factory=_now_utc)
     """The time this notice was last repeated.
 
-    See Pebble's `Notices documentation <https://github.com/canonical/pebble/#notices>`_
+    See Pebble's `Notices documentation <https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/notices/>`_
     for an explanation of what "repeated" means.
     """
 


### PR DESCRIPTION
One typo, one set of docs that have moved.

I haven't bumped the version number, which I think means that the release workflow just fails and there's no new release and all is well? This doesn't seem like it really needs a separate release. But if that causes bad things to happen, I can add that of course.