### PR TITLE
feat: use a slightly more strict type for `AnyJson`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.0.4"
+version = "7.0.5"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -52,7 +52,7 @@ from scenario.logger import logger as scenario_logger
 if TYPE_CHECKING:  # pragma: no cover
     from scenario import Context
 
-AnyJson = Union[str, bool, dict, int, float, list]
+AnyJson = Union[str, bool, Dict[str, "AnyJson"], int, float, List["AnyJson"]]
 RawSecretRevisionContents = RawDataBagContents = Dict[str, str]
 UnitID = int
 


### PR DESCRIPTION
Adjust `AnyJson` so that the type of the nested list/dict is also defined.

This should avoid errors like this:

```
/home/tameyer/code/operator/test/test_testing.py
  /home/tameyer/code/operator/test/test_testing.py:7060:17 - error: Type of "action" is partially unknown
    Type of "action" is "(name: str, params: Mapping[str, str | bool | dict[Unknown, Unknown] | int | float | list[Unknown]] | None = None, id: str | None = None) -> _Event" (reportUnknownMemberType)
1 error, 0 warnings, 0 informations 
```