### PR TITLE
chore: use annotations from the __future__

### DIFF
--- a/.github/workflows/quality_checks.yaml
+++ b/.github/workflows/quality_checks.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - 7.0
 
 jobs:
   linting:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
-        exclude: "^(tests/demo_pkg_inline/build.py)$"
-      - id: pyupgrade
-        files: "^(tests/demo_pkg_inline/build.py)$"
+        args: ["--py38-plus"]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.0.4"
+version = "7.0.6"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/scenario/context.py
+++ b/scenario/context.py
@@ -2,11 +2,13 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from __future__ import annotations
+
 import functools
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 import ops
 
@@ -61,9 +63,9 @@ class Manager:
 
     def __init__(
         self,
-        ctx: "Context",
+        ctx: Context,
         arg: _Event,
-        state_in: "State",
+        state_in: State,
     ):
         self._ctx = ctx
         self._arg = arg
@@ -71,7 +73,7 @@ class Manager:
 
         self._emitted: bool = False
 
-        self.ops: Optional["Ops"] = None
+        self.ops: Ops | None = None
 
     @property
     def charm(self) -> ops.CharmBase:
@@ -95,7 +97,7 @@ class Manager:
         self.ops = ops
         return self
 
-    def run(self) -> "State":
+    def run(self) -> State:
         """Emit the event and proceed with charm execution.
 
         This can only be done once.
@@ -245,12 +247,12 @@ class CharmEvents:
 
     @staticmethod
     @_copy_doc(ops.RelationCreatedEvent)
-    def relation_created(relation: "RelationBase"):
+    def relation_created(relation: RelationBase):
         return _Event(f"{relation.endpoint}_relation_created", relation=relation)
 
     @staticmethod
     @_copy_doc(ops.RelationJoinedEvent)
-    def relation_joined(relation: "RelationBase", *, remote_unit: Optional[int] = None):
+    def relation_joined(relation: RelationBase, *, remote_unit: int | None = None):
         return _Event(
             f"{relation.endpoint}_relation_joined",
             relation=relation,
@@ -260,9 +262,9 @@ class CharmEvents:
     @staticmethod
     @_copy_doc(ops.RelationChangedEvent)
     def relation_changed(
-        relation: "RelationBase",
+        relation: RelationBase,
         *,
-        remote_unit: Optional[int] = None,
+        remote_unit: int | None = None,
     ):
         return _Event(
             f"{relation.endpoint}_relation_changed",
@@ -273,10 +275,10 @@ class CharmEvents:
     @staticmethod
     @_copy_doc(ops.RelationDepartedEvent)
     def relation_departed(
-        relation: "RelationBase",
+        relation: RelationBase,
         *,
-        remote_unit: Optional[int] = None,
-        departing_unit: Optional[int] = None,
+        remote_unit: int | None = None,
+        departing_unit: int | None = None,
     ):
         return _Event(
             f"{relation.endpoint}_relation_departed",
@@ -287,7 +289,7 @@ class CharmEvents:
 
     @staticmethod
     @_copy_doc(ops.RelationBrokenEvent)
-    def relation_broken(relation: "RelationBase"):
+    def relation_broken(relation: RelationBase):
         return _Event(f"{relation.endpoint}_relation_broken", relation=relation)
 
     @staticmethod
@@ -336,8 +338,8 @@ class CharmEvents:
     @_copy_doc(ops.ActionEvent)
     def action(
         name: str,
-        params: Optional[Mapping[str, "AnyJson"]] = None,
-        id: Optional[str] = None,
+        params: Mapping[str, AnyJson] | None = None,
+        id: str | None = None,
     ):
         kwargs = {}
         if params:
@@ -405,26 +407,26 @@ class Context:
                 manager.run()
     """
 
-    juju_log: List["JujuLogLine"]
+    juju_log: list[JujuLogLine]
     """A record of what the charm has sent to juju-log"""
-    app_status_history: List["_EntityStatus"]
+    app_status_history: list[_EntityStatus]
     """A record of the app statuses the charm has set"""
-    unit_status_history: List["_EntityStatus"]
+    unit_status_history: list[_EntityStatus]
     """A record of the unit statuses the charm has set"""
-    workload_version_history: List[str]
+    workload_version_history: list[str]
     """A record of the workload versions the charm has set"""
-    removed_secret_revisions: List[int]
+    removed_secret_revisions: list[int]
     """A record of the secret revisions the charm has removed"""
-    emitted_events: List[ops.EventBase]
+    emitted_events: list[ops.EventBase]
     """A record of the events (including custom) that the charm has processed"""
-    requested_storages: Dict[str, int]
+    requested_storages: dict[str, int]
     """A record of the storages the charm has requested"""
-    action_logs: List[str]
+    action_logs: list[str]
     """The logs associated with the action output, set by the charm with :meth:`ops.ActionEvent.log`
 
     This will be empty when handling a non-action event.
     """
-    action_results: Optional[Dict[str, Any]]
+    action_results: dict[str, Any] | None
     """A key-value mapping assigned by the charm as a result of the action.
 
     This will be ``None`` if the charm never calls :meth:`ops.ActionEvent.set_results`
@@ -437,17 +439,17 @@ class Context:
 
     def __init__(
         self,
-        charm_type: Type["CharmType"],
-        meta: Optional[Dict[str, Any]] = None,
+        charm_type: type[CharmType],
+        meta: dict[str, Any] | None = None,
         *,
-        actions: Optional[Dict[str, Any]] = None,
-        config: Optional[Dict[str, Any]] = None,
-        charm_root: Optional[Union[str, Path]] = None,
+        actions: dict[str, Any] | None = None,
+        config: dict[str, Any] | None = None,
+        charm_root: str | Path | None = None,
         juju_version: str = _DEFAULT_JUJU_VERSION,
         capture_deferred_events: bool = False,
         capture_framework_events: bool = False,
-        app_name: Optional[str] = None,
-        unit_id: Optional[int] = 0,
+        app_name: str | None = None,
+        unit_id: int | None = 0,
         app_trusted: bool = False,
     ):
         """Represents a simulated charm's execution context.
@@ -516,26 +518,26 @@ class Context:
         self.capture_framework_events = capture_framework_events
 
         # streaming side effects from running an event
-        self.juju_log: List["JujuLogLine"] = []
-        self.app_status_history: List["_EntityStatus"] = []
-        self.unit_status_history: List["_EntityStatus"] = []
-        self.exec_history: Dict[str, List["ExecArgs"]] = {}
-        self.workload_version_history: List[str] = []
-        self.removed_secret_revisions: List[int] = []
-        self.emitted_events: List[ops.EventBase] = []
-        self.requested_storages: Dict[str, int] = {}
+        self.juju_log: list[JujuLogLine] = []
+        self.app_status_history: list[_EntityStatus] = []
+        self.unit_status_history: list[_EntityStatus] = []
+        self.exec_history: dict[str, list[ExecArgs]] = {}
+        self.workload_version_history: list[str] = []
+        self.removed_secret_revisions: list[int] = []
+        self.emitted_events: list[ops.EventBase] = []
+        self.requested_storages: dict[str, int] = {}
 
         # set by Runtime.exec() in self._run()
-        self._output_state: Optional["State"] = None
+        self._output_state: State | None = None
 
         # operations (and embedded tasks) from running actions
-        self.action_logs: List[str] = []
-        self.action_results: Optional[Dict[str, Any]] = None
-        self._action_failure_message: Optional[str] = None
+        self.action_logs: list[str] = []
+        self.action_results: dict[str, Any] | None = None
+        self._action_failure_message: str | None = None
 
         self.on = CharmEvents()
 
-    def _set_output_state(self, output_state: "State"):
+    def _set_output_state(self, output_state: State):
         """Hook for Runtime to set the output state."""
         self._output_state = output_state
 
@@ -550,14 +552,14 @@ class Context:
         storage_root.mkdir(parents=True, exist_ok=True)
         return storage_root
 
-    def _record_status(self, state: "State", is_app: bool):
+    def _record_status(self, state: State, is_app: bool):
         """Record the previous status before a status change."""
         if is_app:
             self.app_status_history.append(state.app_status)
         else:
             self.unit_status_history.append(state.unit_status)
 
-    def __call__(self, event: "_Event", state: "State"):
+    def __call__(self, event: _Event, state: State):
         """Context manager to introspect live charm object before and after the event is emitted.
 
         Usage::
@@ -574,7 +576,7 @@ class Context:
         """
         return Manager(self, event, state)
 
-    def run_action(self, action: str, state: "State"):
+    def run_action(self, action: str, state: State):
         """Use `run()` instead.
 
         :private:
@@ -584,7 +586,7 @@ class Context:
             "and find the results in `ctx.action_results`",
         )
 
-    def run(self, event: "_Event", state: "State") -> "State":
+    def run(self, event: _Event, state: State) -> State:
         """Trigger a charm execution with an event and a State.
 
         Calling this function will call ``ops.main`` and set up the context according to the
@@ -662,7 +664,7 @@ class Context:
         return self._output_state
 
     @contextmanager
-    def _run(self, event: "_Event", state: "State"):
+    def _run(self, event: _Event, state: State):
         runtime = Runtime(
             charm_spec=self.charm_spec,
             juju_version=self.juju_version,

--- a/scenario/errors.py
+++ b/scenario/errors.py
@@ -38,7 +38,7 @@ class StateValidationError(RuntimeError):
 
 
 class MetadataNotFoundError(RuntimeError):
-    """Raised when Scenario can't find a metadata file in the provided charm root."""
+    """Raised when a metadata file can't be found in the provided charm root."""
 
 
 class ActionMissingFromContextError(Exception):

--- a/scenario/errors.py
+++ b/scenario/errors.py
@@ -9,6 +9,8 @@ used by the framework to signal errors or inconsistencies in the charm tests
 themselves.
 """
 
+from __future__ import annotations
+
 
 class ContextSetupError(RuntimeError):
     """Raised by Context when setup fails."""

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -24,6 +24,7 @@ from typing import (
     Final,
     Generic,
     Iterable,
+    List,
     Literal,
     Mapping,
     NoReturn,

--- a/scenario/state.py
+++ b/scenario/state.py
@@ -962,8 +962,8 @@ class Container(_max_posargs(1)):
         container = Container(
             name='foo',
             execs={
-                scenario.Exec(['whoami'], return_code=0, stdout='ubuntu'),
-                scenario.Exec(
+                Exec(['whoami'], return_code=0, stdout='ubuntu'),
+                Exec(
                     ['dig', '+short', 'canonical.com'],
                     return_code=0,
                     stdout='185.125.190.20\\n185.125.190.21',
@@ -2024,10 +2024,10 @@ class _Action(_max_posargs(1)):
     Used to simulate ``juju run``, passing in any parameters. For example::
 
         def test_backup_action():
-            ctx = scenario.Context(MyCharm)
+            ctx = Context(MyCharm)
             state = ctx.run(
                 ctx.on.action('do_backup', params={'filename': 'foo'}),
-                scenario.State()
+                State()
             )
             assert ctx.action_results == ...
     """

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
     ops~=2.15
     pyright==1.1.347
 commands =
-    pyright scenario
+    pyright --pythonversion=3.8 scenario
 
 [testenv:lint-tests]
 description = Lint test files.


### PR DESCRIPTION
The goal here is to reduce the use of the name "Scenario" in the docs, to control where it appears when the docs are included at ops.readthedocs.io.

Using `from __future__ import annotations` seems to make Sphinx much happier when doing the class signatures, avoiding odd text like `~scenario.state.CloudCredential` instead of the expected link with text "CloudCredential" and destination that class.

When adding those imports, pyupgrade transformed all the type annotations - I wasn't previously aware that the future import made this possible in 3.8, but it seems to be the case. I've run all the tests with 3.8, 3.9, 3.10, 3.11, and 3.12 and they all pass, and I've manually tested in 3.8 and everything seems to work without any problems. I like this much more, so it seems like a win-win.

(To be clear: that means most of the changes in this PR are automatic via pyupgrade).

The pyupgrade pre-commit hook was running twice, one with no version restrictions for a specific file that doesn't seem to exist any more, so I've removed the duplication. I've also changed pyupgrade and pyright to target 3.8 compatibility.

A couple of docstrings are changed to use the `State()` style rather than `scenario.State()` style.